### PR TITLE
Install linter as komodo-lint

### DIFF
--- a/komodo/lint.py
+++ b/komodo/lint.py
@@ -132,7 +132,7 @@ def get_args():
     return args
 
 
-if __name__ == '__main__':
+def lint_main():
     args = get_args()
     logging.basicConfig(format='%(message)s', level=args.loglevel)
 
@@ -156,3 +156,7 @@ if __name__ == '__main__':
         exit(0)  # currently we allow erronous version numbers
 
     exit('Error in komodo configuration.')
+    
+if __name__ == '__main__':
+    lint_main()
+    

--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,9 @@ setup(
     package_dir={'komodo' : 'komodo'},
     scripts=['bin/kmd'],
     test_suite='tests',
+    entry_points={
+        'console_scripts': [
+            'komodo-lint = komodo.lint:lint_main',
+            ]
+        }
 )


### PR DESCRIPTION
Make the linter available as an executable from the command line when komodo is installed