### PR TITLE
Clone version directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 dist: trusty
 language: python
 
+python:
+  - '2.7'
+
 env:
   matrix:
     - UNIT_TEST=1

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -33,10 +33,14 @@ def grab(path, filename = None, version = None, protocol = None,
         shell('wget --quiet {} -O {}'.format(path, filename))
         #return urlretrieve(path, filename = filename)
     elif protocol in ('git'):
-        shell('{} clone -q --recursive -- {} {}'.format(git, path, filename))
-        with pushd(filename):
-            shell('{} fetch --tags'.format(git))
-            shell('{} checkout -q {}'.format(git, version))
+        shell(
+            '{git} clone '
+            '-b {version} '
+            '--depth 1 '
+            '-q --recursive '
+            '-- {path} {filename}'
+            ''.format(git=git, version=version, path=path, filename=filename)
+        )
 
     elif protocol in ('nfs', 'fs-ln'):
         shell('cp --recursive --symbolic-link {} {}'.format(path, filename))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+shell
 pyyaml


### PR DESCRIPTION
If the main branch of a repository is broken beyond cloning Komodo will fail. With this change we clone the requested branch or tag directly. In addition, I've set `depth 1`, so this patch might also lead to slightly faster cloning time.

*Note:*
`shell` was missing from the requirements and _Komodo_ did not immediately seem to be Python 3 compabitle. Did fix version and update dependencies. Python 3 compatibility can be dealt with in another PR.