### PR TITLE
Remove depth from git fetch

### DIFF
--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -36,7 +36,6 @@ def grab(path, filename = None, version = None, protocol = None,
         shell(
             '{git} clone '
             '-b {version} '
-            '--depth 1 '
             '-q --recursive '
             '-- {path} {filename}'
             ''.format(git=git, version=version, path=path, filename=filename)


### PR DESCRIPTION
Version for an application is wrong when scm_version is used and the
depth arguments is included. The last applicable tag will not be cloned
and as such the version given would be 0.0.dev+..

When looking through the issues the following popped up: https://github.com/equinor/komodo/issues/16 I believe this issue can be closed as this is the reason this PR exists (although correct behaviour was observed prior to the `depth` keyword being included, and that is much later than the issue date)