### PR TITLE
WIP: make komodo python 3 compatible

### DIFF
--- a/bin/kmd
+++ b/bin/kmd
@@ -50,9 +50,9 @@ def main(args):
         with open('{}/{}'.format(args.release, target), 'w') as f:
             f.write(komodo.shell(['m4 enable.m4',
                            '-D komodo_prefix={}'.format(tmp_prefix),
-                           '-D komodo_pyver={}'.format('2.7'),
+                           '-D komodo_pyver={}'.format('3.6'),
                            '-D komodo_release={}'.format(args.release),
-                           tmpl]))
+                           tmpl]).decode("utf-8"))
 
     releasedoc = os.path.join(args.release, args.release)
     with open(args.pkgs) as p, open(args.repo) as r, open(releasedoc, 'w') as y:

--- a/bin/kmd
+++ b/bin/kmd
@@ -101,10 +101,11 @@ def main(args):
         if repo[pkg][ver]['make'] != 'pip': continue
 
         stripped_ver = ver.split("+")[0]
+        print(komodo.shell(['{}/bin/pip freeze --local pipfreeze.txt']))
         print(komodo.shell(['{}/bin/pip'.format(install_root),
                'install {}=={}'.format(pkg, stripped_ver),
                '--prefix', os.path.join(args.prefix, args.release, 'root'),
-               '--force-reinstall',
+               '--force-reinstall -r pipfreeze.txt',
                '--no-index',
                '--find-links {}'.format(args.cache),
                repo[pkg][ver].get('makeopts')

--- a/bin/kmd
+++ b/bin/kmd
@@ -101,11 +101,11 @@ def main(args):
         if repo[pkg][ver]['make'] != 'pip': continue
 
         stripped_ver = ver.split("+")[0]
-        print(komodo.shell(['{}/bin/pip freeze --local > pipfreeze.txt']))
         print(komodo.shell(['{}/bin/pip'.format(install_root),
                'install {}=={}'.format(pkg, stripped_ver),
                '--prefix', os.path.join(args.prefix, args.release, 'root'),
-               '--force-reinstall -r pipfreeze.txt',
+               '--force-reinstall',
+               '--no-deps',
                '--no-index',
                '--find-links {}'.format(args.cache),
                repo[pkg][ver].get('makeopts')

--- a/bin/kmd
+++ b/bin/kmd
@@ -101,7 +101,7 @@ def main(args):
         if repo[pkg][ver]['make'] != 'pip': continue
 
         stripped_ver = ver.split("+")[0]
-        print(komodo.shell(['{}/bin/pip freeze --local pipfreeze.txt']))
+        print(komodo.shell(['{}/bin/pip freeze --local > pipfreeze.txt']))
         print(komodo.shell(['{}/bin/pip'.format(install_root),
                'install {}=={}'.format(pkg, stripped_ver),
                '--prefix', os.path.join(args.prefix, args.release, 'root'),

--- a/bin/kmd
+++ b/bin/kmd
@@ -100,8 +100,9 @@ def main(args):
     for pkg, ver in pkgs.items():
         if repo[pkg][ver]['make'] != 'pip': continue
 
+        stripped_ver = ver.split("+")[0]
         print(komodo.shell(['{}/bin/pip'.format(install_root),
-               'install {}=={}'.format(pkg, ver),
+               'install {}=={}'.format(pkg, stripped_ver),
                '--prefix', os.path.join(args.prefix, args.release, 'root'),
                '--force-reinstall',
                '--no-index',

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -108,6 +108,7 @@ def pip(pkg, ver, pkgpath, prefix, dlprefix, *args, **kwargs):
            '--prefix {}'.format(prefix),
            '--no-index',
            '--find-links {}'.format(dlprefix),
+           '--no-deps',
            kwargs.get('makeopts', '')]
 
     print('Installing {} ({}) from pip'.format(pkg, ver))

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import yaml as yml
 
-from shell import shell, pushd
+from .shell import shell, pushd
 
 flatten = itr.chain.from_iterable
 

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -102,7 +102,8 @@ def rsync(pkg, ver, pkgpath, prefix, *args, **kwargs):
 
 def pip(pkg, ver, pkgpath, prefix, dlprefix, *args, **kwargs):
     # pip should be in the tmp root, which is already added to PATH
-    cmd = ['pip install {}=={}'.format(pkg, ver),
+    stripped_ver = ver.split("+")[0]
+    cmd = ['pip install {}=={}'.format(pkg, stripped_ver),
            '--root {}'.format(kwargs['fakeroot']),
            '--prefix {}'.format(prefix),
            '--no-index',

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -10,7 +10,7 @@ import yaml as yml
 try: from urllib.request import urlretrieve
 except ImportError: from urllib import urlretrieve
 
-from shell import shell, pushd
+from .shell import shell, pushd
 
 def eprint(*args, **kwargs):
     return print(*args, file = sys.stderr, **kwargs)

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -52,9 +52,10 @@ def grab(path, filename = None, version = None, protocol = None,
         shell('rsync -a {}/ {}'.format(path, filename))
 
     elif protocol in ('pypi'):
+        stripped_filename = filename.split("+")[0]
         shell([pip, 'download',
                     '--dest .',
-                    normalize_filename(filename)])
+                    normalize_filename(stripped_filename)])
 
     else:
         raise NotImplementedError('Unknown protocol {}'.format(protocol))

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -33,12 +33,13 @@ def grab(path, filename = None, version = None, protocol = None,
         shell('wget --quiet {} -O {}'.format(path, filename))
         #return urlretrieve(path, filename = filename)
     elif protocol in ('git'):
+        stripped_version = version.split("+")[0]
         shell(
             '{git} clone '
             '-b {version} '
             '-q --recursive '
             '-- {path} {filename}'
-            ''.format(git=git, version=version, path=path, filename=filename)
+            ''.format(git=git, version=stripped_version, path=path, filename=filename)
         )
 
     elif protocol in ('nfs', 'fs-ln'):

--- a/python-mk.sh
+++ b/python-mk.sh
@@ -37,39 +37,12 @@ done
 
 set -x
 
-./configure --prefix=$PREFIX            \
-            --enable-shared             \
-            --enable-optimizations      \
-            --with-ensurepip=upgrade    \
+./configure --prefix=$PREFIX                    \
+            --enable-shared                     \
+            --enable-optimizations              \
+            --with-ensurepip=install            \
+            "LDFLAGS=-Wl,-rpath=$PREFIX/lib"    \
             $OPTS
 
 make -j$JOBS
-make -j$JOBS altinstall
-
-ln -s $PREFIX/bin/python3 $PREFIX/bin/python
-
-# get a fresh pip as a part of the installation
-$PREFIX/bin/pip install \
-    --upgrade --ignore-installed --force-reinstall --prefix $PREFIX \
-    pip
-
-# this is a mega hack
-# the problem arises because of a subtle detail in distutils and sysconfig.
-#
-# distutils detects that the python that tries to it is in a python source
-# tree, in which case it assumes that it wants to hard-link all scripts with a
-# shebang (#!) to this particular interpreter.
-#
-# This isn't ideal since we want the install to be relocatable (in fact, we
-# know for sure that we *will* relocate it).
-#
-# Additionally, the sysconfig module, which is queried when building non-pure
-# modules against this particular python wants to grab python's build flags
-# etc, records the paths from the build configuration. These won't match up to
-# the target paths of komodo, so sed to replace them all with the actual target
-# install path.
-
-#if [ -n ${TARGET+x} ]; then
-#    find $PREFIX -type f -exec grep -Iq . {} \; -and \
-#        -exec sed --in-place --follow-symlinks s,$PREFIX,$TARGET, {} \;
-#fi
+make -j$JOBS install


### PR DESCRIPTION
Make komodo run with python3, and beeing able to deploy software on both versions.