### PR TITLE
Remove args when pip installing git downloaded libs

### DIFF
--- a/setup-py.sh
+++ b/setup-py.sh
@@ -36,11 +36,7 @@ while test $# -gt 0; do
     shift
 done
 
-PYTHONEXECUTABLE=$PREFIX/bin/python
-
-pip install . \
-    --global-option build --global-option=--executable=$PYTHONEXECUTABLE \
-    --root $FAKEROOT                                                     \
-    --no-deps                                                            \
+pip install .           \
+    --root $FAKEROOT    \
+    --no-deps           \
     --prefix $PREFIX
-


### PR DESCRIPTION
Not sure why these are present - they was used when pip installing dependencies on our packages - or at least they were present in the code. Will try to remove these and make the installation more like how normal pip packages is installed. 

Don't think this will fix the dirty version issue - but at least it's a good thing removing fluff we don't need (hopefully)