### PR TITLE
Add script to set permissions on builds

### DIFF
--- a/jenkins/set_permissions.sh
+++ b/jenkins/set_permissions.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Missing required positional argument FILE"
+    exit 1
+fi
+
+find $1 -type f -exec chmod o+r {} \;
+find $1 -type f -executable -exec chmod o+rx {} \;
+find $1 -type d -exec chmod o+xr {} \;


### PR DESCRIPTION
Fixes https://github.com/equinor/scout/issues/164

After landing, `PERMISSIONS_EXEC` can be changed from `/project/res/bin/res_perm` to `../jenkins/set_permissions.sh` in all komodo build jobs.