### PR TITLE
Patch RPATH in Komodo's ELF binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 
 python:
   - '2.7'
+  - '3.6'
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - ./configure
   - make
   - sudo make install
+  - popd
 
   # Install komodo dependencies
   - pip install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,25 +14,18 @@ matrix:
   allow_failures:
     - env: INTEGRATION_TEST=1
 
-before_install:
-  - export PYTHONPATH=$PWD:$PYTHONPATH
-  - echo $PYTHONPATH
-  - mkdir ws
-  - mkdir pfx
-  - export WS=$PWD/ws
-  - export PFX=$PWD/pfx
-
 install:
+  - pip install pytest
   - pip install .
 
 before_script:
-  - ls
+  - rm -r komodo
   - python -c "import komodo;print(komodo.__file__);print(komodo.__version__)"
 
 script:
-  - if [[ ! -z $UNIT_TEST ]]; then ./setup.py test ; fi
+  - if [[ ! -z $UNIT_TEST ]]; then pytest tests ; fi
 
   - if [[ ! -z $LINT_TEST ]]; then python -m komodo.lint examples/releases/unstable.yml examples/repository.yml ; fi
   - if [[ ! -z $LINT_TEST ]]; then python -m komodo.lint examples/releases/ecl.yml examples/repository.yml ; fi
 
-  - if [[ ! -z $INTEGRATION_TEST ]]; then bin/kmd examples/releases/ecl.yml examples/repository.yml --workspace $WS --prefix $PFX --release integration --renamer rename.ul; fi
+  - if [[ ! -z $INTEGRATION_TEST ]]; then bin/kmd examples/releases/ecl.yml examples/repository.yml --workspace /tmp/ws --prefix /tmp/pfx --release integration --renamer rename.ul; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ env:
     - LINT_TEST=1
     - INTEGRATION_TEST=1
 
+addons:
+  apt:
+    packages:
+      # This is needed to compile x86 programs in one of the tests
+      - gcc-multilib
+
 matrix:
   allow_failures:
     - env: INTEGRATION_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,15 @@ matrix:
     - env: INTEGRATION_TEST=1
 
 install:
+  # Install patchelf
+  - git clone https://github.com/equinor/patchelf
+  - pushd patchelf
+  - ./bootstrap.sh
+  - ./configure
+  - make
+  - sudo make install
+
+  # Install komodo dependencies
   - pip install pytest
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 addons:
   apt:
     packages:
+      - patchelf
       # This is needed to compile x86 programs in one of the tests
       - gcc-multilib
 
@@ -22,15 +23,6 @@ matrix:
     - env: INTEGRATION_TEST=1
 
 install:
-  # Install patchelf
-  - git clone https://github.com/equinor/patchelf
-  - pushd patchelf
-  - ./bootstrap.sh
-  - ./configure
-  - make
-  - sudo make install
-  - popd
-
   # Install komodo dependencies
   - pip install pytest
   - pip install .

--- a/bin/kmd
+++ b/bin/kmd
@@ -112,6 +112,7 @@ def main(args):
         print(komodo.shell(shell_input, sudo=args.sudo))
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
+    komodo.fixup_rpath(args.prefix, args.release)
 
     # run any post-install scripts on the release
     if args.postinst:

--- a/bin/kmd
+++ b/bin/kmd
@@ -114,11 +114,6 @@ def main(args):
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
 
-    print('Fixup RPATHs in all compatible ELF files')
-    root = os.path.join(args.prefix, args.release, "root")
-    rpath = "{0}/lib:{0}/lib64".format(root)
-    elf.patch_all(root, rpath, args.patchelf)
-
     # run any post-install scripts on the release
     if args.postinst:
         komodo.shell([args.postinst, os.path.join(args.prefix, args.release)])

--- a/bin/kmd
+++ b/bin/kmd
@@ -112,7 +112,9 @@ def main(args):
         print(komodo.shell(shell_input, sudo=args.sudo))
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
-    komodo.fixup_rpath(args.prefix, args.release)
+
+    print('Fixup RPATHs in all compatible ELF files')
+    komodo.fixup_rpaths(args.prefix, args.release, args.patchelf)
 
     # run any post-install scripts on the release
     if args.postinst:
@@ -138,6 +140,7 @@ if __name__ == '__main__':
     parser.add_argument('--pip',   type = str, default = 'pip')
     parser.add_argument('--git',   type = str, default = 'git')
     parser.add_argument('--pyver', type = str, default = '2.7')
+    parser.add_argument('--patchelf', type = str, default = os.environ.get("PATCHELF_EXEC", "patchelf"))
 
     parser.add_argument('--sudo',       action = 'store_true')
     parser.add_argument('--workspace',  type = str, default = None)

--- a/bin/kmd
+++ b/bin/kmd
@@ -114,6 +114,12 @@ def main(args):
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
 
+    print('Merging lib64/ into lib/')
+    root = os.path.join(args.prefix, args.release, "root")
+    komodo.shell("rsync -rav {0}/lib64/* {0}/lib/".format(root))
+    komodo.shell("rmdir {0}/lib64".format(root))
+    komodo.shell("ln -s {0}/lib {0}/lib64".format(root))
+
     # run any post-install scripts on the release
     if args.postinst:
         komodo.shell([args.postinst, os.path.join(args.prefix, args.release)])

--- a/bin/kmd
+++ b/bin/kmd
@@ -115,7 +115,9 @@ def main(args):
     komodo.fixup_python_shebangs(args.prefix, args.release)
 
     print('Fixup RPATHs in all compatible ELF files')
-    elf.patch_all(os.path.join(args.prefix, args.release), args.patchelf)
+    root = os.path.join(args.prefix, args.release, "root")
+    rpath = "{0}/lib:{0}/lib64".format(root)
+    elf.patch_all(root, rpath, args.patchelf)
 
     # run any post-install scripts on the release
     if args.postinst:

--- a/bin/kmd
+++ b/bin/kmd
@@ -90,7 +90,6 @@ def main(args):
     # everything from pip
     os.environ['LD_LIBRARY_PATH'] = ':'.join([
                                         os.path.join(install_root, 'lib'),
-                                        os.path.join(install_root, 'lib64'),
                                         os.environ.get('LD_LIBRARY_PATH', '')])
 
     os.environ['PYTHONPATH'] = komodo.pypaths(install_root, pkgs.get('python'))
@@ -113,12 +112,6 @@ def main(args):
         print(komodo.shell(shell_input, sudo=args.sudo))
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
-
-    print('Merging lib64/ into lib/')
-    root = os.path.join(args.prefix, args.release, "root")
-    komodo.shell("rsync -rav {0}/lib64/* {0}/lib/".format(root))
-    komodo.shell("rmdir {0}/lib64".format(root))
-    komodo.shell("ln -s {0}/lib {0}/lib64".format(root))
 
     # run any post-install scripts on the release
     if args.postinst:

--- a/bin/kmd
+++ b/bin/kmd
@@ -9,6 +9,7 @@ import yaml as yml
 import logging
 
 import komodo
+from komodo import elf
 
 def main(args):
     args.prefix = os.path.abspath(args.prefix)
@@ -114,7 +115,7 @@ def main(args):
     komodo.fixup_python_shebangs(args.prefix, args.release)
 
     print('Fixup RPATHs in all compatible ELF files')
-    komodo.fixup_rpaths(args.prefix, args.release, args.patchelf)
+    elf.patch_all(os.path.join(args.prefix, args.release), args.patchelf)
 
     # run any post-install scripts on the release
     if args.postinst:

--- a/enable.csh.in
+++ b/enable.csh.in
@@ -27,13 +27,6 @@ else
     setenv MANPATH komodo_prefix/share/man
 endif
 
-if $?LD_LIBRARY_PATH then
-    setenv _PRE_KOMODO_LD_PATH "$LD_LIBRARY_PATH"
-    setenv LD_LIBRARY_PATH komodo_prefix/lib:komodo_prefix/lib64:$LD_LIBRARY_PATH
-else
-    setenv LD_LIBRARY_PATH komodo_prefix/lib:komodo_prefix/lib64
-endif
-
 setenv KOMODO_RELEASE komodo_release
 
 set local_script=komodo_prefix/../local.csh

--- a/enable.in
+++ b/enable.in
@@ -56,9 +56,6 @@ export PATH=komodo_prefix/bin${PATH:+:${PATH}}
 export _PRE_KOMODO_MANPATH="$MANPATH"
 export MANPATH=komodo_prefix/share/man:${MANPATH}
 
-export _PRE_KOMODO_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
-export LD_LIBRARY_PATH=komodo_prefix/lib:komodo_prefix/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-
 export _PRE_KOMODO_PS1="${PS1:-}"
 export PS1="(${KOMODO_RELEASE}) ${PS1}"
 

--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -18,58 +18,6 @@ def _is_shebang(s):
     return s.startswith('#!/') and 'python' in s
 
 
-def is_valid_elf_file(path):
-    """Checks whether a given file is a valid amd64 Linux ELF file that is either
-    an executable or a dynamic library that we can patch.
-
-    """
-    if not os.path.isfile(path) or os.path.islink(path):
-        return False
-
-    with open(path, "rb") as f:
-        # First 16 bytes are the E_IDENT section of the ELF header. The 4 next
-        # bytes are two uint16_t's representing E_TYPE and E_MACHINE.
-        head = f.read(20)
-
-    # Check magic string
-    if len(head) != 20 or head[:4] != b"\x7fELF":
-        return False
-
-    # EI_CLASS must be ELFCLASS64 = 2 (amd64)
-    if head[4] != b"\x02":
-        return False
-    # EI_DATA must be ELFDATA2LSB = 1 (Little-Endian, two's complement)
-    if head[5] != b"\x01":
-        return False
-    # EI_VERSION must be 1 (the only one that exists at time of writing)
-    if head[6] != b"\x01":
-        return False
-    # EI_OSABI must be either ELFOSABI_SYSV = 0 or ELFOSABI_GNU = 3
-    # (GNU/Linux). Seems like some distros prefer SYSV (Debian) while others
-    # prefer to specify GNU (RHEL). Either works for us.
-    if head[7] != b"\0" and head[7] != b"\x03":
-        return False
-    # We ignore EI_ABIVERSION
-    # The rest of the E_IDENT section is padding
-
-    # e_type must be either ET_EXEC = 3 (executable binary) or ET_DYN = 4
-    # (shared library). These are uint16_t's, and we have assumed ELFDATA2LSB,
-    # which is Little-Endian, so these byte-strings are little-endian.
-    e_type    = head[16:18]
-    if e_type != b"\x03\0" and e_type != b"\x04\0":
-        return False
-
-    # Machine architecture. For safety we allow only EM_X86_64 = 62 (amd64).
-    # Again, this is a uint16_t, so bytes are encoded as little-endian.
-    e_machine = head[18:20]
-    if e_machine != b"\x3e\0":
-        return False
-
-    # We don't care about the rest of the header, since it deals with positions
-    # of different data sections within the file and other nonsense.
-    return True
-
-
 def fixup_python_shebangs(prefix, release):
     """Fix shebang to $PREFIX/bin/python.
 
@@ -103,23 +51,6 @@ def fixup_python_shebangs(prefix, release):
         binpath_ = os.path.join(prefix, release, 'root', 'bin', bin_)
         if os.path.exists(binpath_):
             shell(sedfxp.format(python_, binpath_))
-
-
-def fixup_rpaths(prefix, release, patchelf):
-    """TODO: Explain"""
-    release_root = os.path.join(prefix, release, "root")
-    rpath = "{0}/lib:{0}/lib64".format(release_root)
-
-    for root, _dirs, files in os.walk(release_root):
-        for fn in files:
-            try:
-                with open(fn, "rb") as f:
-                    if f.read(4) != b"\x7fELF":
-                        continue
-            except IOError:
-                continue
-            prog = os.path.join(root, fn)
-            shell("{} \"--set-rpath={}\" \"{}\"".format(patchelf, rpath, prog))
 
 
 def strip_version(version):

--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -1,6 +1,7 @@
 """Komodo software distribution build system."""
 
 import os
+import glob
 
 from .build import make, pypaths
 from .fetch import fetch
@@ -49,6 +50,24 @@ def fixup_python_shebangs(prefix, release):
         binpath_ = os.path.join(prefix, release, 'root', 'bin', bin_)
         if os.path.exists(binpath_):
             shell(sedfxp.format(python_, binpath_))
+
+
+def fixup_rpaths(prefix, release):
+    """TODO: Explain"""
+    release_root = os.path.join(prefix, release, "root")
+    rpath = "{0}/lib:{0}/lib64".format(release_root)
+
+    for root, _dirs, files in os.walk(release_root):
+        for fn in files:
+            try:
+                with open(fn, "rb") as f:
+                    if f.read(4) != b"\x7fELF":
+                        continue
+            except IOError:
+                continue
+            prog = os.path.join(root, fn)
+            shell("/project/oompf/patchelf/patchelf \"--set-rpath={rpath}\" \"{prog}\"".format(rpath=rpath, prog=prog))
+    
 
 def strip_version(version):
     """

--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import glob
+import struct
 
 from .build import make, pypaths
 from .fetch import fetch
@@ -15,6 +16,58 @@ from .maintainer import maintainers
 def _is_shebang(s):
     """Checks if the string potentially is a Python shebang."""
     return s.startswith('#!/') and 'python' in s
+
+
+def is_valid_elf_file(path):
+    """Checks whether a given file is a valid amd64 Linux ELF file that is either
+    an executable or a dynamic library that we can patch.
+
+    """
+    if not os.path.isfile(path) or os.path.islink(path):
+        return False
+
+    with open(path, "rb") as f:
+        # First 16 bytes are the E_IDENT section of the ELF header. The 4 next
+        # bytes are two uint16_t's representing E_TYPE and E_MACHINE.
+        head = f.read(20)
+
+    # Check magic string
+    if len(head) != 20 or head[:4] != b"\x7fELF":
+        return False
+
+    # EI_CLASS must be ELFCLASS64 = 2 (amd64)
+    if head[4] != b"\x02":
+        return False
+    # EI_DATA must be ELFDATA2LSB = 1 (Little-Endian, two's complement)
+    if head[5] != b"\x01":
+        return False
+    # EI_VERSION must be 1 (the only one that exists at time of writing)
+    if head[6] != b"\x01":
+        return False
+    # EI_OSABI must be either ELFOSABI_SYSV = 0 or ELFOSABI_GNU = 3
+    # (GNU/Linux). Seems like some distros prefer SYSV (Debian) while others
+    # prefer to specify GNU (RHEL). Either works for us.
+    if head[7] != b"\0" and head[7] != b"\x03":
+        return False
+    # We ignore EI_ABIVERSION
+    # The rest of the E_IDENT section is padding
+
+    # e_type must be either ET_EXEC = 3 (executable binary) or ET_DYN = 4
+    # (shared library). These are uint16_t's, and we have assumed ELFDATA2LSB,
+    # which is Little-Endian, so these byte-strings are little-endian.
+    e_type    = head[16:18]
+    if e_type != b"\x03\0" and e_type != b"\x04\0":
+        return False
+
+    # Machine architecture. For safety we allow only EM_X86_64 = 62 (amd64).
+    # Again, this is a uint16_t, so bytes are encoded as little-endian.
+    e_machine = head[18:20]
+    if e_machine != b"\x3e\0":
+        return False
+
+    # We don't care about the rest of the header, since it deals with positions
+    # of different data sections within the file and other nonsense.
+    return True
 
 
 def fixup_python_shebangs(prefix, release):
@@ -52,7 +105,7 @@ def fixup_python_shebangs(prefix, release):
             shell(sedfxp.format(python_, binpath_))
 
 
-def fixup_rpaths(prefix, release):
+def fixup_rpaths(prefix, release, patchelf):
     """TODO: Explain"""
     release_root = os.path.join(prefix, release, "root")
     rpath = "{0}/lib:{0}/lib64".format(release_root)
@@ -66,8 +119,8 @@ def fixup_rpaths(prefix, release):
             except IOError:
                 continue
             prog = os.path.join(root, fn)
-            shell("/project/oompf/patchelf/patchelf \"--set-rpath={rpath}\" \"{prog}\"".format(rpath=rpath, prog=prog))
-    
+            shell("{} \"--set-rpath={}\" \"{}\"".format(patchelf, rpath, prog))
+
 
 def strip_version(version):
     """

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -156,6 +156,7 @@ def make(pkgfile, repofile, prefix = None,
                                            [os.path.join(fakeprefix, 'lib'),
                                             os.path.join(fakeprefix, 'lib64'),
                                             os.environ.get('LD_LIBRARY_PATH')]))
+    os.environ['LDFLAGS'] = "-Wl,-rpath,{0}/lib:{0}/lib64".format(prefix)
     extra_makeopts = os.environ.get('extra_makeopts')
 
     pkgpaths = ['{}-{}'.format(pkg, pkgs[pkg]) for pkg in pkgorder]

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -143,8 +143,8 @@ def make(pkgfile, repofile, prefix = None,
 
     fakeprefix = fakeroot + prefix
     shell(['mkdir -p', fakeprefix])
-    os.mkdir(os.join(fakeprefix, "lib"))
-    os.symlink(os.join(fakeprefix, "lib"), os.join(fakeprefix, "lib64"))
+    os.mkdir(os.path.join(fakeprefix, "lib"))
+    os.symlink(os.path.join(fakeprefix, "lib"), os.path.join(fakeprefix, "lib64"))
     prefix = os.path.abspath(prefix)
 
     # assuming there always is a python *and* that python will be installed
@@ -158,7 +158,7 @@ def make(pkgfile, repofile, prefix = None,
     os.environ['LD_LIBRARY_PATH'] = ':'.join(filter(None,
                                            [os.path.join(fakeprefix, 'lib'),
                                             os.environ.get('LD_LIBRARY_PATH')]))
-    rpath = os.join(prefix, "lib")
+    rpath = os.path.join(prefix, "lib")
     os.environ['LDFLAGS'] = "-Wl,-rpath," + rpath
     extra_makeopts = os.environ.get('extra_makeopts')
 

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import yaml as yml
 import komodo
+from komodo import elf
 
 from .shell import shell, pushd
 
@@ -156,7 +157,8 @@ def make(pkgfile, repofile, prefix = None,
                                            [os.path.join(fakeprefix, 'lib'),
                                             os.path.join(fakeprefix, 'lib64'),
                                             os.environ.get('LD_LIBRARY_PATH')]))
-    os.environ['LDFLAGS'] = "-Wl,-rpath,{0}/lib:{0}/lib64".format(prefix)
+    rpath = "{0}/lib:{0}/lib64".format(prefix)
+    os.environ['LDFLAGS'] = "-Wl,-rpath," + rpath
     extra_makeopts = os.environ.get('extra_makeopts')
 
     pkgpaths = ['{}-{}'.format(pkg, pkgs[pkg]) for pkg in pkgorder]
@@ -188,6 +190,9 @@ def make(pkgfile, repofile, prefix = None,
                                        cmake    = cmk,
                                        pip      = pip,
                                        fakeroot = fakeroot)
+
+        if current.get("fixup_rpaths", False):
+            elf.patch_all(root, rpath)
 
 
 if __name__ == '__main__':

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -143,6 +143,8 @@ def make(pkgfile, repofile, prefix = None,
 
     fakeprefix = fakeroot + prefix
     shell(['mkdir -p', fakeprefix])
+    os.mkdir(os.join(fakeprefix, "lib"))
+    os.symlink(os.join(fakeprefix, "lib"), os.join(fakeprefix, "lib64"))
     prefix = os.path.abspath(prefix)
 
     # assuming there always is a python *and* that python will be installed
@@ -155,9 +157,8 @@ def make(pkgfile, repofile, prefix = None,
                                    os.environ['PATH']])
     os.environ['LD_LIBRARY_PATH'] = ':'.join(filter(None,
                                            [os.path.join(fakeprefix, 'lib'),
-                                            os.path.join(fakeprefix, 'lib64'),
                                             os.environ.get('LD_LIBRARY_PATH')]))
-    rpath = "{0}/lib:{0}/lib64".format(prefix)
+    rpath = os.join(prefix, "lib")
     os.environ['LDFLAGS'] = "-Wl,-rpath," + rpath
     extra_makeopts = os.environ.get('extra_makeopts')
 

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -78,7 +78,10 @@ def patch(path, libdir, patchelf="patchelf"):
     proc = subprocess.Popen([patchelf, "--print-rpath", path], stdout=subprocess.PIPE)
     stdout, stderr = proc.communicate()
 
-    old_rpath = str(stdout.strip(), encoding="ascii")
+    if six.PY2:
+        old_rpath = str(stdout.strip(), encoding="ascii")
+    else:
+        old_rpath = stdout.strip()
     if len(old_rpath) > 0:
         rpath = "{}:{}".format(old_rpath, rpath)
 

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -20,11 +20,11 @@ def is_valid_elf_file(path):
     # Check magic string
     if len(headstr) != 20 or headstr[:4] != b"\x7fELF":
         return False
-
     if six.PY2:
         head = tuple(map(ord, headstr))
     else:
         head = headstr
+
     # EI_CLASS must be ELFCLASS64 = 2 (64-bit registers)
     if head[4] != 2:
         return False
@@ -42,11 +42,11 @@ def is_valid_elf_file(path):
     # We ignore EI_ABIVERSION
     # The rest of the E_IDENT section is padding
 
-    # e_type must be either ET_EXEC = 3 (executable binary) or ET_DYN = 4
+    # e_type must be either ET_EXEC = 2 (executable binary) or ET_DYN = 3
     # (shared library). These are uint16_t's, and we have assumed ELFDATA2LSB,
     # which is Little-Endian, so these byte-strings are little-endian.
     e_type    = headstr[16:18]
-    if e_type != b"\x03\0" and e_type != b"\x04\0":
+    if e_type != b"\x02\0" and e_type != b"\x03\0":
         return False
 
     # Machine architecture. For safety we allow only EM_X86_64 = 62 (amd64).
@@ -78,7 +78,7 @@ def patch(path, libdir, patchelf="patchelf"):
     proc = subprocess.Popen([patchelf, "--print-rpath", path], stdout=subprocess.PIPE)
     stdout, stderr = proc.communicate()
 
-    old_rpath = stdout.strip()
+    old_rpath = str(stdout.strip(), encoding="ascii")
     if len(old_rpath) > 0:
         rpath = "{}:{}".format(old_rpath, rpath)
 

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+from komodo.shell import shell
+
+
+def is_valid_elf_file(path):
+    """Checks whether a given file is a valid amd64 Linux ELF file that is either
+    an executable or a dynamic library that we can patch.
+
+    """
+    if not os.path.isfile(path) or os.path.islink(path):
+        return False
+
+    with open(path, "rb") as f:
+        # First 16 bytes are the E_IDENT section of the ELF header. The 4 next
+        # bytes are two uint16_t's representing E_TYPE and E_MACHINE.
+        head = f.read(20)
+
+    # Check magic string
+    if len(head) != 20 or head[:4] != b"\x7fELF":
+        return False
+
+    # EI_CLASS must be ELFCLASS64 = 2 (64-bit registers)
+    if head[4] != b"\x02":
+        return False
+    # EI_DATA must be ELFDATA2LSB = 1 (Little-Endian, two's complement)
+    if head[5] != b"\x01":
+        return False
+    # EI_VERSION must be 1 (the only one that exists at time of writing)
+    if head[6] != b"\x01":
+        return False
+    # EI_OSABI must be either ELFOSABI_SYSV = 0 or ELFOSABI_GNU = 3
+    # (GNU/Linux). Seems like some distros prefer SYSV (Debian) while others
+    # prefer to specify GNU (RHEL). Either works for us.
+    if head[7] != b"\0" and head[7] != b"\x03":
+        return False
+    # We ignore EI_ABIVERSION
+    # The rest of the E_IDENT section is padding
+
+    # e_type must be either ET_EXEC = 3 (executable binary) or ET_DYN = 4
+    # (shared library). These are uint16_t's, and we have assumed ELFDATA2LSB,
+    # which is Little-Endian, so these byte-strings are little-endian.
+    e_type    = head[16:18]
+    if e_type != b"\x03\0" and e_type != b"\x04\0":
+        return False
+
+    # Machine architecture. For safety we allow only EM_X86_64 = 62 (amd64).
+    # Again, this is a uint16_t, so bytes are encoded as little-endian.
+    e_machine = head[18:20]
+    if e_machine != b"\x3e\0":
+        return False
+
+    # We don't care about the rest of the header, since it deals with positions
+    # of different data sections within the file and other nonsense.
+    return True
+
+
+def list_elfs(path):
+    for root, _dirs, files in os.walk(path):
+        for fn in files:
+            elf = os.path.join(root, fn)
+            if is_valid_elf_file(elf):
+                yield elf
+
+
+def patch(path, libdir, patchelf="patchelf"):
+    rpath = libdir
+    proc = subprocess.Popen([patchelf, "--print-rpath", path], stdout=subprocess.PIPE)
+    stdout, stderr = proc.communicate()
+
+    old_rpath = stdout.strip()
+    if len(old_rpath) > 0:
+        rpath = "{}:{}".format(old_rpath, rpath)
+
+    shell("{} --set-rpath {} {}".format(patchelf, rpath, path))
+
+
+def patch_all(root, libdir, patchelf="patchelf"):
+    for path in list_elfs(root):
+        patch(path, libdir, patchelf)

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -56,6 +56,7 @@ def is_valid_elf_file(path):
 
 
 def list_elfs(path):
+    """List all patchable ELF files in a directory and its subdirectories."""
     for root, _dirs, files in os.walk(path):
         for fn in files:
             elf = os.path.join(root, fn)
@@ -64,6 +65,10 @@ def list_elfs(path):
 
 
 def patch(path, libdir, patchelf="patchelf"):
+    """Patch a single ELF file by appending the new RPATH to the old RPATH, if any,
+    using patchelf
+
+    """
     rpath = libdir
     proc = subprocess.Popen([patchelf, "--print-rpath", path], stdout=subprocess.PIPE)
     stdout, stderr = proc.communicate()
@@ -76,5 +81,6 @@ def patch(path, libdir, patchelf="patchelf"):
 
 
 def patch_all(root, libdir, patchelf="patchelf"):
+    """Patch all patchable ELF files so that libdir is part of their RPATH"""
     for path in list_elfs(root):
         patch(path, libdir, patchelf)

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import six
 from komodo.shell import shell
 
 
@@ -20,7 +21,10 @@ def is_valid_elf_file(path):
     if len(headstr) != 20 or headstr[:4] != b"\x7fELF":
         return False
 
-    head = tuple(map(int, headstr))
+    if six.PY2:
+        head = tuple(map(ord, headstr))
+    else:
+        head = headstr
     # EI_CLASS must be ELFCLASS64 = 2 (64-bit registers)
     if head[4] != 2:
         return False

--- a/komodo/elf.py
+++ b/komodo/elf.py
@@ -79,9 +79,9 @@ def patch(path, libdir, patchelf="patchelf"):
     stdout, stderr = proc.communicate()
 
     if six.PY2:
-        old_rpath = str(stdout.strip(), encoding="ascii")
-    else:
         old_rpath = stdout.strip()
+    else:
+        old_rpath = str(stdout.strip(), encoding="ascii")
     if len(old_rpath) > 0:
         rpath = "{}:{}".format(old_rpath, rpath)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     },
     scripts=["bin/kmd"],
     test_suite="tests",
-    install_requires=["shell", "PyYAML", "ruamel.yaml", "PyGithub"],
+    install_requires=["shell", "PyYAML", "ruamel.yaml", "PyGithub", "six"],
     entry_points={
         "console_scripts": [
             "komodo-check-symlinks = komodo.symlink.sanity_check:sanity_main",

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -46,7 +46,9 @@ def test_dyn(tmpdir):
 
 def test_symlink(tmpdir):
     """Symlinks may point to ELF files outside of the komodo release, so it is
-imperative that we do not touch them"""
+    imperative that we do not touch them
+
+    """
     with tmpdir.as_cwd():
         os.symlink("/bin/bash", "symlink")
 
@@ -64,7 +66,10 @@ def test_object_file(tmpdir):
 
 
 def test_incorrect_arch(tmpdir):
-    """We only support amd64 CPU architecture. We test an x86 binary compiled with the m32 flag"""
+    """We only support amd64 CPU architecture. We test an x86 binary compiled with
+    the m32 flag
+
+    """
     with tmpdir.as_cwd():
         _compile("gcc -m32 {code}")
 
@@ -73,6 +78,11 @@ def test_incorrect_arch(tmpdir):
 
 
 def test_patch(tmpdir):
+    """We test the patching functionality by a shared object (liba.so) and an
+    executable (a.out). The executable links to liba.so, where the function 'a'
+    is located
+
+    """
     with tmpdir.as_cwd():
         _compile("gcc -shared -fPIC -oliba.so {code}", code="int a(){return 42;}")
         _compile("gcc {code} -L. -la", code="int main(){return a();}")
@@ -84,11 +94,28 @@ def test_patch(tmpdir):
         assert subprocess.call(["./a.out"]) == 127
 
         # Program returns 42 as expected when we patchelf
-        elf.patch("a.out", os.getcwd())
+        elf.patch("a.out", os.getcwd(), os.environ.get("PATCHELF_EXEC", "patchelf"))
         assert subprocess.call(["./a.out"]) == 42
 
 
 def test_patch_with_existing_rpath(tmpdir):
+    """When shipping portable binaries it is imperative to set the RPATH so that
+    your portable binary is able to locate any of its dependencies. Thus, it is
+    normal to find executables with '$ORIGIN/lib' or '$ORIGIN/../lib' as their
+    RPATH. '$ORIGIN' is a magic string that tells the linker (default:
+    '/usr/lib/ld-linux.so.2') to replace it with the directory in which the
+    executable resides.
+
+    This is also common in PyPI packages with binary wheels, and thus is very
+    important that we support it.
+
+    We test this by creating two libraries: liba.so and libb.so. The first
+    exists in our $PWD, and the second exists in $PWD/lib. The first simulates
+    a system-installed library while the second simulates a portably-shipped
+    library. 'a.out' uses both libraries, but has information about where to
+    find 'libb.so' only
+
+    """
     with tmpdir.as_cwd():
         tmpdir.mkdir("lib")
         _compile("gcc -shared -fPIC -oliba.so {code}", code="int a(){return 1;}")
@@ -112,14 +139,15 @@ def test_patch_with_existing_rpath(tmpdir):
 
         # Program succeeds when we patchelf because it prepends the RPATH
         # elf.patch("a.out", os.getcwd())
-        elf.patch("a.out", "$ORIGIN")
+        elf.patch("a.out", "$ORIGIN", os.environ.get("PATCHELF_EXEC", "patchelf"))
         assert subprocess.call(["./a.out"]) == 3
 
 
 def test_find_elfs(tmpdir):
+    """Create a fake release tree and test that we're collecting the right files"""
     bins = ["bin/bash", "bin/python"]
     libs = ["lib/libpython3.6.so", "lib/python3.6/site-packages/a/.libs/libz.so"]
-    syms = {"bin/python3": "bin/python"}
+    syms = {"bin/python3": "bin/python", "usr/bin": "/bin"}
     txts = ["bin/pytest", "lib/python3.6/site-packages/a/__init__.py"]
 
     with tmpdir.as_cwd():

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -1,0 +1,121 @@
+import sys
+import subprocess
+import re
+import os
+import shutil
+from komodo import is_valid_elf_file
+
+
+# NOTE: If these tests are failing, know that they're meant for AMD64 Linux
+# machines only. If we're testing komodo on a different CPU architecture or OS
+# kernel, these will need to be updated.
+
+
+def _compile(args, code="int main() {}\n"):
+    with open("main.c", "w") as f:
+        f.write(code)
+    assert subprocess.call(re.split(r"\s+", args.format(code="main.c"))) == 0
+
+
+def test_exec():
+    """Check whether Python is a valid executable (Hint: it is)"""
+    assert is_valid_elf_file(sys.executable)
+
+
+def test_elf_symlink(tmpdir):
+    """We don't like symlinks here"""
+    with tmpdir.as_cwd():
+        os.symlink("/bin/bash", "symlink")
+
+        assert os.path.isfile("symlink")
+        assert not is_valid_elf_file("symlink")
+
+
+def test_dyn(tmpdir):
+    """Compile a dynamic library and test it"""
+    with tmpdir.as_cwd():
+        _compile("gcc -shared {code}")
+
+        assert os.path.isfile("a.out")
+        assert is_valid_elf_file("a.out")
+
+
+def test_object_file(tmpdir):
+    """Object files (.o) are ELF, but contain no linking information"""
+    with tmpdir.as_cwd():
+        _compile("gcc -c -omain.o {code}")
+
+        assert os.path.isfile("main.o")
+        assert not is_valid_elf_file("main.o")
+
+
+def test_incorrect_arch(tmpdir):
+    """We only support amd64 CPU architecture. We test an x86 binary compiled with the m32 flag"""
+    with tmpdir.as_cwd():
+        _compile("gcc -m32 {code}")
+
+        assert os.path.isfile("a.out")
+        assert not is_valid_elf_file("a.out")
+
+
+def test_patch(tmpdir):
+    with tmpdir.as_cwd():
+        _compile("gcc -shared -fPIC -oliba.so {code}", code="int a(){return 42;}")
+        _compile("gcc {code} -L. -la", code="int main(){return a();}")
+
+        assert os.path.isfile("liba.so")
+        assert os.path.isfile("a.out")
+
+        # Program returns -1 (127) because it can't find the library
+        assert subprocess.call(["./a.out"]) == 127
+
+        # Program returns 42 as expected when we patchelf
+        assert subprocess.call(["patchelf", "--set-rpath", os.getcwd(), "a.out"]) == 0
+        assert subprocess.call(["./a.out"]) == 42
+
+
+def test_patch_with_existing_rpath(tmpdir):
+    with tmpdir.as_cwd():
+        tmpdir.mkdir("lib")
+        _compile("gcc -shared -fPIC -oliba.so {code}", code="int a(){return 1;}")
+        _compile("gcc -shared -fPIC -olib/libb.so {code}", code="int b(){return 2;}")
+        _compile(
+            "gcc {code} -Wl,-rpath,$ORIGIN/lib -L. -L./lib -la -lb",
+            code="int main(){return a()+b();}",
+        )
+
+        assert os.path.isfile("liba.so")
+        assert os.path.isfile("lib/libb.so")
+        assert os.path.isfile("a.out")
+
+        # Program returns -1 (127) because it can't find liba.so
+        assert subprocess.call(["./a.out"]) == 127
+
+        # Program succeeds because we have specified LD_LIBRARY_PATH
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = os.getcwd()
+        assert subprocess.call(["./a.out"], env=env) == 3
+
+        # Program succeeds when we patchelf because it prepends the RPATH
+        rpath = "{}:$ORIGIN/lib".format(os.getcwd())
+        assert subprocess.call(["patchelf", "--set-rpath", rpath, "a.out"])
+        assert subprocess.call(["./a.out"]) == 3
+
+
+def test_find_elfs(tmpdir):
+    bins = ("bin/bash", "bin/python")
+    libs = ("lib/libpython3.6.so", "lib/python3.6/site-packages/a/.libs/libz.so")
+    txts = ("bin/pytest", "lib/python3.6/site-packages/a/__init__.py")
+
+    with tmpdir.as_cwd():
+        for bin_ in bins:
+            tmpdir.mkdir(os.path.dirname(bin_))
+            shutil.copyfile(sys.executable, bin_)
+        for lib in libs:
+            pass
+        for txt in txts:
+            with open(txt, "w") as f:
+                f.write("#!/usr/bin/env python\nprint('Hi!')\n")
+
+        elfs = elf.find_all(os.getcwd(), "bleeding-py36")
+        assert set(elfs) == set(bins + libs)

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -138,8 +138,7 @@ def test_patch_with_existing_rpath(tmpdir):
         assert subprocess.call(["./a.out"], env=env) == 3
 
         # Program succeeds when we patchelf because it prepends the RPATH
-        # elf.patch("a.out", os.getcwd())
-        elf.patch("a.out", "$ORIGIN", os.environ.get("PATCHELF_EXEC", "patchelf"))
+        elf.patch("a.out", os.getcwd(), os.environ.get("PATCHELF_EXEC", "patchelf"))
         assert subprocess.call(["./a.out"]) == 3
 
 
@@ -152,7 +151,7 @@ def test_find_elfs(tmpdir):
 
     with tmpdir.as_cwd():
         # Make directories
-        for path in bins + libs + syms.keys() + txts:
+        for path in bins + libs + list(syms) + txts:
             dir = os.path.dirname(path)
             if not os.path.isdir(dir):
                 os.makedirs(dir)

--- a/tests/test_elf.py
+++ b/tests/test_elf.py
@@ -32,7 +32,7 @@ def _make_text_file(dest):
 
 def test_exec():
     """Check whether Python is a valid executable (Hint: it is)"""
-    assert elf.is_valid_elf_file(sys.executable)
+    assert elf.is_valid_elf_file(os.path.realpath(sys.executable))
 
 
 def test_dyn(tmpdir):

--- a/tests/test_non_deployed.py
+++ b/tests/test_non_deployed.py
@@ -14,7 +14,6 @@ def _create_links(links, root=""):
         os.symlink(
             os.path.join(root, src),
             os.path.join(root, target),
-            target_is_directory=True,
         )
 
 


### PR DESCRIPTION
Resolves: #97 

Use https://github.com/Equinor/patchelf instead of https://github.com/NixOS/patchelf . The upstream clears old RPATHs, which doesn't play well when `ld` tries to compress the entries. In Stavanger, you can do `export PATCHELF_EXEC=/project/oompf/patchelf/patchelf`