### PR TITLE
Have pip force-reinstall packages always

### DIFF
--- a/komodo/build.py
+++ b/komodo/build.py
@@ -106,6 +106,7 @@ def pip_install(pkg, ver, pkgpath, prefix, dlprefix, pip='pip', *args, **kwargs)
            'install {}=={}'.format(pkg, komodo.strip_version(ver)),
            '--root {}'.format(kwargs['fakeroot']),
            '--prefix {}'.format(prefix),
+           '--force-reinstall',
            '--no-index',
            '--no-deps',
            '--find-links {}'.format(dlprefix),


### PR DESCRIPTION
Pip, if it finds an existing package, doesn't install it again even if we've specified `--root`/`--prefix`. This was discovered when we updated the version of `six` to be the same as latest. Komodo has `six` as one of its dependencies and so pip discovered that it was already installed in the temporary Komodo virtualenv, and so didn't install it into the release.

I still need to have Jenkins use Python 3 for running Komodo regardless of what the bundle python will be, but that isn't critical yet.