### PR TITLE
Transpiler

### DIFF
--- a/komodo/prettier.py
+++ b/komodo/prettier.py
@@ -59,7 +59,7 @@ def is_repository(config):
     )
 
 
-def prettier(yaml_input_dict):
+def prettier(yaml_input_dict, check_type=True):
     """Takes in a string corresponding to a YAML Komodo configuration, and returns
     the corresponding prettified YAML string."""
 
@@ -69,7 +69,7 @@ def prettier(yaml_input_dict):
     )
     ruamel_instance.width = 1000  # Avoid ruamel wrapping long
 
-    komodo_repository = is_repository(yaml_input_dict)
+    komodo_repository = check_type and is_repository(yaml_input_dict)
 
     # On Python3.6+, sorted_config can just be an
     # ordinary dict as insertion order is then preserved.
@@ -117,10 +117,10 @@ def prettified_yaml(filepath, check_only=True):
     return True
 
 
-def write_to_file(repository, filename):
+def write_to_file(repository, filename, check_type=True):
     if type(repository) == dict:
         repository = ruamel.yaml.comments.CommentedMap(repository)
-    output_str = prettier(repository)
+    output_str = prettier(repository, check_type)
     with open(file=filename, mode="w") as output_file:
         output_file.write(output_str)
 

--- a/komodo/release_transpiler.py
+++ b/komodo/release_transpiler.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import sys
+from argparse import ArgumentError, ArgumentParser, ArgumentTypeError, RawTextHelpFormatter
+from komodo import load_yaml, write_to_file, prettified_yaml
+
+
+
+def build_matrix_file(release_base, release_folder, builtins):
+    py27 = load_yaml("{}/{}-py27.yml".format(release_folder, release_base))
+
+    py36 = load_yaml("{}/{}-py36.yml".format(release_folder, release_base))
+
+    all_packages = set(py36.keys()).union(py27.keys())
+
+    compiled = {}
+
+    for p in all_packages:
+        if p in builtins:
+            compiled[p] = builtins[p]
+        elif py27.get(p) == py36.get(p):
+            compiled[p] = py27.get(p)
+        else:
+            compiled[p] = {"py27": py27.get(p), "py36": py36.get(p)}
+
+    write_to_file(compiled, "{}.yml".format(release_base), False)
+
+def _build(packages, py_ver, rhel_ver):
+    release_dict = {}
+    for p, versions in packages.items():
+        if rhel_ver in versions:
+            version = versions[rhel_ver][py_ver]
+        elif py_ver in versions:
+            version = versions[py_ver]
+        else:
+            version = versions
+
+        if version:
+            release_dict[p] = version
+    return release_dict
+
+
+def transpile_releases(matrix_file, output_folder):
+    release_base = os.path.basename(matrix_file).strip(".yml")
+    release_folder = os.path.dirname(matrix_file)
+    release_matrix = load_yaml("{}.yml".format(os.path.join(release_folder, release_base)))
+    for rhel_ver in ("rhel6", "rhel7"):
+        for py_ver in ("py27", "py36"):
+            release_dict = _build(release_matrix, py_ver, rhel_ver)
+            filename = "{rel}-{pyver}-{rhel_version}.yml".format(
+                rel=release_base, pyver=py_ver, rhel_version=rhel_ver
+            )
+            write_to_file(release_dict, os.path.join(output_folder, filename))
+
+
+def combine(args):
+    build_matrix_file(args.release_base, args.release_folder, load_yaml(args.override_mapping))
+
+def transpile(args):
+    transpile_releases(args.matrix_file, args.output_folder)
+
+
+
+def main():
+    parser = ArgumentParser(description="Build release files.", formatter_class=RawTextHelpFormatter)
+
+    subparsers = parser.add_subparsers(
+        title="Commands",
+        description="Combine - build matrix file\n"
+        "Transpile - generate release files",
+        help="Available sub commands",
+        dest="mode",
+    )
+    subparsers.required = True
+
+    matrix_parser = subparsers.add_parser(
+        "combine",
+        description="""
+Combine release files into a matrix file.
+Output format:
+example-package:
+  rhel6:
+    py27 : # package not included in release
+    py36 : 5.11.13
+  rhel7:
+    py27 : # package not included in release
+    py36 : 5.11.13+builtin""",
+        formatter_class=RawTextHelpFormatter
+    )
+    matrix_parser.set_defaults(func=combine)
+    matrix_parser.add_argument(
+        "--release-base",
+        help="Name of the release to handle",
+        required=True
+    )
+    matrix_parser.add_argument(
+        "--release-folder",
+        help="Folder with existing release file",
+        required=True
+    )
+    matrix_parser.add_argument(
+        "--override-mapping",
+        help="File containing explicit matrix packages",
+        required=True
+    )
+
+    transpile_parser = subparsers.add_parser(
+        "transpile",
+        description="Transpile a matrix file into separate release files."
+    )
+    transpile_parser.set_defaults(func=transpile)
+    transpile_parser.add_argument(
+        "--matrix-file",
+        help="Yaml file describing the release matrix",
+        required=True
+    )
+    transpile_parser.add_argument(
+        "--output-folder",
+        help="Folder to output new release files",
+        required=True
+    )
+    args = parser.parse_args()
+    args.func(args)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             "komodo-lint-package-status = komodo.lint_package_status:main",
             "komodo-lint-maturity = komodo.lint_maturity:main",
             'komodo-clean-repository = komodo.release_cleanup:main',
+            'komodo-transpiler = komodo.release_transpiler:main',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
             "komodo-create-symlinks = komodo.symlink.create_links:symlink_main",
             "komodo-lint = komodo.lint:lint_main",
             "komodo-non-deployed = komodo.deployed:deployed_main",
-            "komodo-prettier = komodo.prettier:prettier_main",
             "komodo-suggest-symlinks = komodo.symlink.suggester.cli:main",
             "komodo-extract-dep-graph = komodo.extract_dep_graph:main",
             "komodo-lint-package-status = komodo.lint_package_status:main",

--- a/tests/data/test_release_matrix.yml
+++ b/tests/data/test_release_matrix.yml
@@ -1,0 +1,16 @@
+lib1:
+  rhel6:
+    py27: 0.1.2
+    py36: 1.2.3
+  rhel7:
+    py27: 0.1.2+builtin
+    py36: 1.2.3+builtin
+lib2:
+  py27: 1.2.3
+  py36: 2.3.4
+lib3:
+  py27: 2.3.4
+  py36: 3.4.5
+lib4:
+  py27: 3.4.5
+  py36:

--- a/tests/test_release_transpiler.py
+++ b/tests/test_release_transpiler.py
@@ -1,0 +1,42 @@
+import os
+from komodo.release_transpiler import build_matrix_file, transpile_releases
+from tests import _get_test_root, _load_yaml
+import yaml
+
+
+builtins = {
+    "lib1" : {
+        "rhel6": {
+            "py27" : "0.1.2",
+            "py36" : "1.2.3"
+        },
+        "rhel7": {
+            "py27" : "0.1.2+builtin",
+            "py36" : "1.2.3+builtin"
+        }
+    },
+}
+
+
+def test_build_release_matrix(tmpdir):
+    release_base = "2020.01.a1"
+    release_folder = os.path.join(_get_test_root(), "data/test_releases/")
+    with tmpdir.as_cwd():
+        build_matrix_file(release_base, release_folder, builtins)
+        new_release_file = "{}.yml".format(release_base)
+        assert os.path.isfile(new_release_file)
+        with open(new_release_file) as f:
+            release_matrix = yaml.safe_load(f)
+        assert release_matrix["lib1"] == builtins["lib1"]
+        assert release_matrix["lib2"]["py27"] == "1.2.3"
+        assert release_matrix["lib2"]["py36"] == "2.3.4"
+
+
+def test_transpile(tmpdir):
+    release_file = os.path.join(_get_test_root(), "data", "test_release_matrix.yml")
+    release_base = os.path.basename(release_file).strip(".yml")
+    with tmpdir.as_cwd():
+        transpile_releases(release_file, os.getcwd())
+        for rhel_ver in ("rhel6", "rhel7"):
+            for py_ver in ("py27", "py36"):
+                assert os.path.isfile("{}-{}-{}.yml".format(release_base, py_ver, rhel_ver))


### PR DESCRIPTION
respolves #116 

The matrix builder including hardcoded builtins are to be removed after creating the initial release matrix files for bleeding and the newest release at the given time.