### PR TITLE
Delay setting LD_LIBRARY_PATH until executing something from bin/

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,16 @@ script:
                 --release travis                                            \
                 --renamer rename.ul                                         \
                 --pip $PIP
-  - tree /tmp/pfx
+  # Build libkmd.so for testing
+  - ci/travis/build_lib.sh /tmp/pfx/travis
 
+  - tree /tmp/pfx
   # Use built komodo
   - source /tmp/pfx/travis/enable
   - which python
   - python --version
   - python -c "import numpy;print(numpy.__file__)"
+  - ci/travis/test_import_lib.py
 
   # Test that everything makes sense
   - '[[ "$(which python)" == "/tmp/pfx/travis/root/bin/python" ]]'

--- a/ci/travis/build_lib.sh
+++ b/ci/travis/build_lib.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+prefix=$1
+
+# Compile
+echo 'char*foo(){return"bar";}' > /tmp/lib.c
+cc -shared -o/tmp/libkmd.so -fPIC /tmp/lib.c
+
+# Copy into komodo release
+cp /tmp/libkmd.so "${prefix}/root/lib"

--- a/ci/travis/test_import_lib.py
+++ b/ci/travis/test_import_lib.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import sys
+import os
+from ctypes import CDLL, c_char_p
+
+
+lib = CDLL("libkmd.so")
+foo = lib.foo
+foo.restype = c_char_p
+foo.argtypes = ()
+
+# Test that libkmd.so is loaded correctly
+val = foo()
+if val != b"bar":
+    sys.stderr.write("foo() returned '{}' instead of 'bar'\n".format(val))
+    sys.exit(1)

--- a/enable.csh.in
+++ b/enable.csh.in
@@ -29,9 +29,7 @@ endif
 
 if $?LD_LIBRARY_PATH then
     setenv _PRE_KOMODO_LD_PATH "$LD_LIBRARY_PATH"
-    setenv LD_LIBRARY_PATH komodo_prefix/lib:komodo_prefix/lib64:$LD_LIBRARY_PATH
-else
-    setenv LD_LIBRARY_PATH komodo_prefix/lib:komodo_prefix/lib64
+    unsetenv LD_LIBRARY_PATH
 endif
 
 setenv KOMODO_RELEASE komodo_release

--- a/enable.in
+++ b/enable.in
@@ -57,7 +57,7 @@ export _PRE_KOMODO_MANPATH="$MANPATH"
 export MANPATH=komodo_prefix/share/man:${MANPATH}
 
 export _PRE_KOMODO_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
-export LD_LIBRARY_PATH=komodo_prefix/lib:komodo_prefix/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+unset LD_LIBRARY_PATH
 
 export _PRE_KOMODO_PS1="${PS1:-}"
 export PS1="(${KOMODO_RELEASE}) ${PS1}"

--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -6,8 +6,11 @@ import shutil
 import sys
 import yaml as yml
 import logging
+from textwrap import dedent
 
 import komodo
+from komodo.shim import create_shims
+
 
 def _main(args):
     args.prefix = os.path.abspath(args.prefix)
@@ -111,6 +114,9 @@ def _main(args):
         print(komodo.shell(shell_input, sudo=args.sudo))
 
     komodo.fixup_python_shebangs(args.prefix, args.release)
+
+    # Create shims
+    create_shims(os.path.join(args.prefix, args.release, "root"))
 
     # run any post-install scripts on the release
     if args.postinst:

--- a/komodo/shim.py
+++ b/komodo/shim.py
@@ -1,0 +1,34 @@
+import os
+from textwrap import dedent
+
+
+shim_template = dedent("""\
+    #!/bin/bash -eu
+    root=$(dirname $0)/..
+    prog=$(basename $0)
+    if [ -z "${_KOMODO_SHIM:-}" ]; then
+        export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        export _KOMODO_SHIM=$prog
+    fi
+    $root/libexec/$prog "$@"
+""")
+
+
+def create_shims(root):
+    print("Creating libexec/ and shims in bin/")
+
+    bin_path = os.path.join(root, "bin")
+    libexec_path = os.path.join(root, "libexec")
+    os.rename(bin_path, libexec_path)
+    os.mkdir(bin_path)
+    for name in os.listdir(libexec_path):
+        src = os.path.join(libexec_path, name)
+        dst = os.path.join(bin_path, name)
+
+        print("{} -> {}".format(src, dst))
+
+        if os.path.isdir(src):
+            continue
+        with open(dst, "w") as f:
+            f.write(shim_template)
+        os.chmod(dst, 0o755)

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -1,0 +1,106 @@
+import os
+import pytest
+import subprocess
+from komodo.shim import create_shims, shim_template
+from textwrap import dedent
+from pathlib import Path
+
+
+binfiles = {
+    "test": "Testfile",
+    "foo": "bar",
+    "python": dedent("""\
+        #!/bin/bash
+        # This is totally a python file
+        exit 42
+    """)
+}
+
+
+def setup_bindir(tmpdir):
+    (tmpdir / "bin").mkdir()
+
+    for name, text in binfiles.items():
+        path = str(tmpdir / "bin" / name)
+        with open(path, "w") as f:
+            f.write(text)
+        os.chmod(path, 0o755)
+
+
+def test_shims_created(tmpdir):
+    with tmpdir.as_cwd():
+        setup_bindir(tmpdir)
+        bin_path = str(tmpdir / "bin")
+        libexec_path = str(tmpdir / "libexec")
+
+        # Check that files were created
+        assert set(binfiles.keys()) == set(os.listdir(bin_path))
+
+        create_shims(str(tmpdir))
+        assert set(binfiles.keys()) == set(os.listdir(bin_path))
+        assert set(binfiles.keys()) == set(os.listdir(libexec_path))
+
+
+def test_libexec_are_binfiles(tmpdir):
+    with tmpdir.as_cwd():
+        setup_bindir(tmpdir)
+        libexec_path = str(tmpdir / "libexec")
+
+        create_shims(str(tmpdir))
+        for name in os.listdir(libexec_path):
+            with open(os.path.join(libexec_path, name)) as f:
+                assert binfiles[name] == f.read()
+
+
+def test_bin_are_shims(tmpdir):
+    with tmpdir.as_cwd():
+        setup_bindir(tmpdir)
+        bin_path = str(tmpdir / "bin")
+
+        create_shims(str(tmpdir))
+        for name in os.listdir(bin_path):
+            with open(os.path.join(bin_path, name)) as f:
+                assert shim_template == f.read()
+
+
+def test_executable(tmpdir):
+    with tmpdir.as_cwd():
+        setup_bindir(tmpdir)
+
+        subprocess.check_output
+
+
+@pytest.mark.parametrize("libdir", ["lib", "lib64"])
+def test_lib(tmpdir, libdir):
+    c_src = 'const char *foo() { return "bar"; }'
+    py_src = dedent("""\
+        #!/usr/bin/env python
+        import sys
+        from ctypes import CDLL, c_char_p
+        lib = CDLL("libfoo.so")
+        foo = lib.foo
+        foo.restype = c_char_p
+        if foo() != b"bar":
+            sys.exit(1)
+    """)
+
+    with tmpdir.as_cwd():
+        with open("lib.c", "w") as f:
+            f.write(c_src)
+
+        (tmpdir / libdir).mkdir()
+        subprocess.call(["cc", "-shared", f"-o{libdir}/libfoo.so", "lib.c", "-fPIC"])
+
+        # Create test script
+        test_path = Path(tmpdir / "bin" / "test")
+        test_path.parent.mkdir()
+        test_path.write_text(py_src, encoding="ascii")
+        test_path.chmod(0o755)
+
+        create_shims(str(tmpdir))
+
+        # Calling test directly should fail
+        assert subprocess.call(["libexec/test"]) == 1
+
+        # Calling via shim should succeed
+        assert subprocess.call(["bin/test"]) == 0


### PR DESCRIPTION
Currently we are setting `LD_LIBRARY_PATH` when komodo is enabled. If it is sourced in the user's `.bashrc`, it breaks a lot of system-managed software, most notably GNOME (Our `libxkbcommon.so` that we ship with komodo causes a segfault in `gnome-shell`).

This is yet another proposal on how to fix this. Instead of changing `LD_LIBRARY_PATH` when komodo is enabled, we delay it until the user actually runs some program that we provide. Thus, `LD_LIBRARY_PATH` affects only the program the user wanted and any child processes that it may spawn.

We do this thusly:
1. Build a release as normal
2. At the end, rename `bin/` to `libexec/`
3. For each entry in `libexec/`:
    1. Create a 0755 entry in `bin/` with the same name, containing the following bash script:
```bash
#!/bin/bash -eu
root=$(dirname $0)/..
prog=$(basename $0)
if [ -z "${_KOMODO_SHIM:-}" ]; then
  if [ -z "${LD_LIBRARY_PATH:-}" ]; then
    export LD_LIBRARY_PATH=$root/lib:$root/lib64
  else
    export LD_LIBRARY_PATH=$root/lib:$root/lib64:$LD_LIBRARY_PATH
  fi
  export _KOMODO_SHIM=$prog
fi
$root/libexec/$prog "$@"
```

---

While this solves the problem of GNOME segfaulting, it isn't without its issues:
1. All of our integration tests need to be rewritten. This is something that likely must be done with the other attempts too.
    1. They all use `virtualenv --system-site-packages` to extend the release with pytest and other testing packages
    2. Some (*libecl*, *libres*) use `ctest`, requiring setting the `LD_LIBRARY_PATH` manually