### PR TITLE
Don't set _KOMODO_SHIM

### DIFF
--- a/komodo/shim.py
+++ b/komodo/shim.py
@@ -6,10 +6,7 @@ shim_template = dedent("""\
     #!/bin/bash -eu
     root=$(dirname $0)/..
     prog=$(basename $0)
-    if [ -z "${_KOMODO_SHIM:-}" ]; then
-        export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-        export _KOMODO_SHIM=$prog
-    fi
+    export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     $root/libexec/$prog "$@"
 """)
 


### PR DESCRIPTION
`komodo_job_dispatch` is a script called by ERT's job queue, which unsets the komodo environment before sourcing it again. Among these things, `LD_LIBRARY_PATH` is removed. However, it doesn't remove `_KOMODO_SHIM`, so the next time a shimmed executable is started, `LD_LIBRARY_PATH` isn't set again.