### PR TITLE
Don't use #!/bin/bash -eu

### DIFF
--- a/komodo/shim.py
+++ b/komodo/shim.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 
 shim_template = dedent("""\
-    #!/bin/bash -eu
+    #!/bin/bash
     root=$(dirname $0)/..
     prog=$(basename $0)
     export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}


### PR DESCRIPTION
Some of our machines have broken `/etc/bash` that checks whether PS1 is set via `${PS1}` instead of `${PS1:-}`.