### PR TITLE
Bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,43 +6,32 @@ python: 3.6
 addons:
   apt:
     packages:
-      - tree
+      - cmake
 
 matrix:
   fast_finish: true
   include:
     - name: Python 2.7.18 target
       env:
-        - TARGET_PYTHON_URL=https://github.com/equinor/portable-pythons/raw/master/bionic/bionic_cp27_18.tar.xz
-        - TARGET_PYTHON_DIR=bionic_cp27_18
-        - TARGET_PYTHON_VERSION="Python 2.7.18"
+        - TARGET_PYTHON_URL=https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Linux-x86_64.sh
+        - 'TARGET_PYTHON_VERSION="Python 2.7.18 :: Anaconda, Inc."'
         - RELEASE=release-py27.yml
 
-    - name: Python 3.8.3 target
+    - name: Python 3.7.7 target
       env:
-        - TARGET_PYTHON_URL=https://github.com/equinor/portable-pythons/raw/master/bionic/bionic_cp38_3.tar.xz
-        - TARGET_PYTHON_DIR=bionic_cp38_3
-        - TARGET_PYTHON_VERSION="Python 3.8.3"
-        - RELEASE=release-py38.yml
-
-before_install:
-  # Prepare komodo environment
-  - virtualenv -ppython3 /tmp/kmd-venv
-  - KMD_PYTHON=/tmp/kmd-venv/bin/python
-
-  # Prepare target python
-  - pushd /tmp
-  - wget $TARGET_PYTHON_URL
-  - tar xvf $TARGET_PYTHON_DIR.tar.xz
-  - PIP=/tmp/${TARGET_PYTHON_DIR}/bin/pip
-  - popd
+        - TARGET_PYTHON_URL=https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.3-Linux-x86_64.sh
+        - TARGET_PYTHON_VERSION="Python 3.7.7"
+        - RELEASE=release-py37.yml
 
 install:
-  - $KMD_PYTHON -m pip install . pytest
+  # Prepare target python
+  - wget -O miniconda.sh $TARGET_PYTHON_URL
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p/tmp/target-python
 
-before_script:
-  - rm -r komodo
-  - $KMD_PYTHON -c "import komodo;print(komodo.__file__);print(komodo.__version__)"
+  # Bootstrap Komodo environment
+  - ./bootstrap.sh /tmp/target-python/bin/python
+  - KMD_PYTHON=$PWD/boot/kmd-env/bin/python
 
 script:
   # Unit tests
@@ -54,17 +43,15 @@ script:
 
   # Full integration test
   - |
-    $KMD_PYTHON -m komodo.cli ci/travis/${RELEASE} ci/travis/repository.yml \
-                --workspace /tmp/ws                                         \
-                --prefix /tmp/pfx                                           \
-                --release travis                                            \
-                --renamer rename.ul                                         \
-                --pip $PIP
+    ./runkmd.sh ci/travis/${RELEASE} ci/travis/repository.yml \
+                --workspace /tmp/kmd-ws                       \
+                --cache /tmp/kmd-cache                        \
+                --prefix /tmp/pfx                             \
+                --release travis                              \
+                --renamer rename.ul
   # Build libkmd.so for testing
   - ci/travis/build_lib.sh /tmp/pfx/travis
 
-  - tree /tmp/pfx
-  # Use built komodo
   - source /tmp/pfx/travis/enable
   - which python
   - python --version

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -eux
+
+function usage {
+    echo "Usage: $0 [TARGET PYTHON EXECUTABLE]"
+    exit 1
+}
+
+[ -z "${1:-}" ] && usage
+[[ ! -f "$1" ]] && usage
+
+python_bin=$1
+
+function cleanup {
+    if [ -d "boot" ]; then
+        echo "boot/ exists, deleting"
+        rm -r boot
+    fi
+
+    if [ -f "runkmd.sh" ]; then
+        echo "runkmd.sh exists, deleting"
+        rm runkmd.sh
+    fi
+}
+
+function install_komodo {
+    # Install the environment that the kmd executable will run in. We also
+    # install the virtualenv package because the user might specify to target
+    # Python 2.7, where the 'venv' module doesn't exist.
+
+    python3_bin=/usr/bin/python3
+
+    if [[ -n "${TRAVIS:-}" ]]; then
+        # Travis provides Python via a virtualenv, lets respect that
+        python3_bin=/opt/python/${TRAVIS_PYTHON_VERSION}/bin/python3
+    fi
+    if [[ ! -f "${python3_bin}" ]]; then
+        # Lets assume we're on an Equinor machine
+        python3_bin=/prog/sdpsoft/python3.6.4/bin/python3
+    fi
+    if [[ ! -f "${python3_bin}" ]]; then
+        echo "Couldn't find a Python 3 binary"
+        exit 1
+    fi
+
+    echo "Installing Komodo"
+    $python3_bin -m venv boot/kmd-env
+    boot/kmd-env/bin/python -m pip install --upgrade pip pytest virtualenv
+    boot/kmd-env/bin/python -m pip install .
+}
+
+function install_devtoolset {
+    # Install devtoolset simply by symlinking everything from its bin. Note that
+    # we don't need to use LD_LIBRARY_PATH or any other environment variables to
+    # get this to work.
+
+    if [[ -n "${TRAVIS:-}" ]]; then
+        # Travis uses Ubuntu which doesn't have devtoolset, but the build tools
+        # are new enough
+        return
+    fi
+    if [[ ! -d "/opt/rh/devtoolset-8" ]]; then
+        echo "Couldn't find Devtoolset 8"
+        exit 1
+    fi
+
+    echo "Using devtoolset-8"
+    for binfile in /opt/rh/devtoolset-8/root/usr/bin/*; do
+        ln -s $binfile boot/bintools/
+    done
+    boot/bintools/gcc --version
+}
+
+function install_cmake {
+    # The RHEL /usr/bin/cmake is CMake 2.8, which is positively ancient,
+    # Use /usr/bin/cmake3 instead.
+
+    cmake_bin=/usr/bin/cmake3
+    if [[ -n "${TRAVIS:-}" ]]; then
+        # On Ubuntu 18.04 (bionic), the 'cmake' package is CMake 3.10
+        cmake_bin=/usr/bin/cmake
+    fi
+    if [[ ! -f "${cmake_bin}" ]]; then
+        echo "Couldn't find a CMake3 executable"
+        exit 1
+    fi
+
+    echo "Using CMake3"
+    ln -s ${cmake_bin} boot/bintools/cmake
+    boot/bintools/cmake --version
+}
+
+function install_git {
+    # git is too old for both RHEL6 and RHEL7, prefer the one from SDPSoft
+    git_bin=/prog/sdpsoft/git-2.8.0/bin/git
+    if [[ ! -f "${git_bin}" ]]; then
+        echo "Couldn't find SDPSoft git, falling back to system git"
+        git_bin=/usr/bin/git
+    fi
+    if [[ ! -f "${git_bin}" ]]; then
+        echo "Couldn't find system git either, failing"
+        exit 1
+    fi
+
+    echo "Using git"
+    ln -s ${git_bin} boot/bintools/git
+    boot/bintools/git --version
+}
+
+function install_build_env {
+    echo "Using ${python_bin} for target"
+    boot/kmd-env/bin/virtualenv --python=${python_bin} boot/build-env
+    boot/build-env/bin/pip install --upgrade pip
+    ln -s $PWD/boot/build-env/bin/pip boot/bintools/
+}
+
+function create_runkmd {
+    cat << EOF > runkmd.sh
+#!/bin/bash
+export PATH=$PWD/boot/bintools:\$PATH
+$PWD/boot/kmd-env/bin/kmd "\$@"
+EOF
+    chmod +x runkmd.sh
+}
+
+cleanup
+mkdir -p boot/bintools
+install_komodo
+install_build_env
+install_devtoolset
+install_cmake
+install_git
+create_runkmd

--- a/ci/travis/release-py37.yml
+++ b/ci/travis/release-py37.yml
@@ -1,4 +1,4 @@
 numpy: 1.18.4
-python: 3.8.3
+python: 3.7.7
 setuptools: 41.4.0
 wheel: 0.33.6

--- a/ci/travis/repository.yml
+++ b/ci/travis/repository.yml
@@ -15,14 +15,14 @@ numpy:
       - python
 
 python:
-  3.8.3:
-    source: /tmp/bionic_cp38_3
+  3.7.7:
+    source: /tmp/target-python
     fetch: fs-cp
     make: rsync
     makeopts: --exclude=site-packages
     maintainer: travis
   2.7.18:
-    source: /tmp/bionic_cp27_18
+    source: /tmp/target-python
     fetch: fs-cp
     make: rsync
     makeopts: --exclude=site-packages


### PR DESCRIPTION
Resolves: #128 

This PR provides a new script `bootstrap.sh`. Pass it the path to the python binary that you wish to use for the target komodo release. Running `bootstrap.sh` creates a directory called `boot/` and a script called `runkmd.sh`. The latter will start the `kmd` executable in the correct komodo build environment, which contains:
* All of Devtoolset-8
* CMake3 symlinked as `cmake`
* git 2.8.0 from SDPSoft if available
* `pip` from `boot/build-env` (virtualenv of the target python version)

Eg: Running `./boostrap.sh /usr/bin/python2.7` will generate an environment for building a Python 2.7 komodo release. Use `./runkmd.sh` as you would `kmd`. The major benefit with this is that regardless of the Python version you give to `bootstrap.sh`, the `kmd` command will use `python3` (3.6 on RHEL7).