### PR TITLE
shim: Use the 'exec' bash builtin

### DIFF
--- a/komodo/shim.py
+++ b/komodo/shim.py
@@ -4,10 +4,8 @@ from textwrap import dedent
 
 shim_template = dedent("""\
     #!/bin/bash
-    root=$(dirname $0)/..
-    prog=$(basename $0)
-    export LD_LIBRARY_PATH=$root/lib:$root/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-    $root/libexec/$prog "$@"
+    export LD_LIBRARY_PATH={root}/lib:{root}/lib64${{LD_LIBRARY_PATH:+:${{LD_LIBRARY_PATH}}}}
+    exec -a "$0" "{root}/libexec/{name}" "$@"
 """)
 
 
@@ -27,5 +25,5 @@ def create_shims(root):
         if os.path.isdir(src):
             continue
         with open(dst, "w") as f:
-            f.write(shim_template)
+            f.write(shim_template.format(root=root, name=name))
         os.chmod(dst, 0o755)

--- a/tests/test_shim.py
+++ b/tests/test_shim.py
@@ -60,7 +60,7 @@ def test_bin_are_shims(tmpdir):
         create_shims(str(tmpdir))
         for name in os.listdir(bin_path):
             with open(os.path.join(bin_path, name)) as f:
-                assert shim_template == f.read()
+                assert shim_template.format(root=tmpdir, name=name) == f.read()
 
 
 def test_executable(tmpdir):


### PR DESCRIPTION
Previously, bash started the shimmed program as a separate process. This change makes it so that the shimmed program takes over the bash process **and** the program thinks it's located in `bin/` (the `-a $0` part). If you run python, it'll:
1. Replace `bash` process with `../libexec/python`
2. Python's `sys.executable` will think it's `../bin/python`. Therefore, any process that uses `sys.executable` will correctly use the shimmed version that sets up the variables instead of directly.

`exec -a $0`