### PR TITLE
add reverse dependency graph extractor

### DIFF
--- a/komodo/reverse_dep_graph.py
+++ b/komodo/reverse_dep_graph.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+import yaml
+import subprocess
+import io
+
+
+def run(base_pkgfile, repofile, dot, display_pkg, out):
+    with open(base_pkgfile) as bp, open(repofile) as r:
+        base_pkgs, repo = yaml.safe_load(bp), yaml.safe_load(r)
+
+    reverse = build_reverse(base_pkgs, repo)
+
+    display_version = base_pkgs[display_pkg]
+
+    if dot:
+        _dump_dot(reverse, display_pkg, display_version, out)
+    else:
+        result = reverse_deps(display_pkg, display_version, reverse)
+        yaml.dump(result, out)
+
+
+def reverse_deps(display_pkg, display_version, reverse):
+    return {
+        f"{display_pkg}-{display_version}": build_doc(display_pkg, reverse)
+        for pkg, version in reverse.items()
+    }
+
+
+def build_reverse(base, repo):
+    reverse = {}
+
+    for pkg, version in base.items():
+        if pkg not in repo:
+            raise SystemExit(f"No package {pkg} in repo")
+        if version not in repo[pkg]:
+            raise SystemExit(f"No version {version} in package {pkg} in repo")
+        repo_version = repo[pkg][version]
+        if "depends" in repo_version:
+            for dep in repo_version["depends"]:
+                if dep not in reverse:
+                    reverse[dep] = set()
+                reverse[dep].add((pkg, version))
+
+    return reverse
+
+
+def _dump_dot(reverse, pkg, version, out):
+    out.write("digraph G {\n")
+    _dump_dot_dep(reverse, pkg, version, out, set())
+    out.write("}")
+
+
+def _dump_dot_dep(reverse, pkg, version, out, seen):
+    if pkg in seen:
+        return
+    id = pkg.lower().replace("-", "_")
+    out.write(f'  {id} [label="{pkg}-{version}"];\n')
+    if pkg in reverse:
+        seen.add(pkg)
+        for rev_dep, rev_version in reverse[pkg]:
+            rev_id = rev_dep.lower().replace("-", "_")
+            out.write(f"  {id} -> {rev_id};\n")
+            _dump_dot_dep(reverse, rev_dep, rev_version, out, seen)
+
+
+def build_doc(pkg, reverse):
+    rev_list = []
+    if pkg not in reverse.keys():
+        return rev_list
+    for rev_dep, rev_version in reverse[pkg]:
+        rev_list.append({f"{rev_dep}-{rev_version}": build_doc(rev_dep, reverse)})
+    return rev_list
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extracts dependencies from a given set of packages where "
+            "versions will be resolved from a complete release file. "
+        )
+    )
+    parser.add_argument(
+        "base_pkgs",
+        type=lambda arg: arg
+        if os.path.isfile(arg)
+        else parser.error("{} is not a file".format(arg)),
+        help="Base file where all packages are listed with wanted versions specified.",
+    )
+    parser.add_argument(
+        "repo",
+        type=lambda arg: arg
+        if os.path.isfile(arg)
+        else parser.error("{} is not a file".format(arg)),
+        help="Repository file with all packages listed with dependencies.",
+    )
+    parser.add_argument(
+        "--pkg",
+        "-p",
+        help="Package to find reverse dependencies for. If not specified, will prompt.",
+    )
+    parser.add_argument(
+        "--out",
+        "-o",
+        help="File to be written with reverse dependencies. If not specified dump to stdout.",
+    )
+    parser.add_argument(
+        "--dot",
+        "-d",
+        action="store_true",
+        help="Write a dot graph file to be rendered with dot",
+    )
+    parser.add_argument(
+        "--display_dot",
+        "-l",
+        action="store_true",
+        help="Try to display graph with dot and eog.",
+    )
+
+    args = parser.parse_args()
+
+    if args.pkg:
+        pkg = args.pkg
+    else:
+        pkg = input("pkg:")
+        print(f"you entered {pkg}")
+
+    if args.out:
+        with open(args.out, "w") as out:
+            run(args.base_pkgs, args.repo, args.dot, pkg, out)
+    elif args.display_dot:
+        dot_proc = subprocess.Popen(
+            ["dot", "-Tpng", "-o"], stdout=subprocess.PIPE, stdin=subprocess.PIPE
+        )
+        display_proc = subprocess.Popen(["display"], stdin=dot_proc.stdout)
+        out = io.TextIOWrapper(dot_proc.stdin, encoding="utf-8", line_buffering=True,)
+        run(args.base_pkgs, args.repo, True, pkg, out)
+        out.close()
+        dot_proc.stdin.close()
+    else:
+        run(args.base_pkgs, args.repo, args.dot, pkg, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reverse_dep_graph.py
+++ b/tests/test_reverse_dep_graph.py
@@ -1,0 +1,107 @@
+import pytest
+
+from komodo import reverse_dep_graph
+import json
+
+REPO = {
+    "package_a": {
+        "1.2.3": {
+            "depends": ["package_b", "package_c", "package_e", "package_f"],
+            "maintainer": "a@b.c",
+            "make": "pip",
+            "source": "pypi",
+        }
+    },
+    "package_b": {
+        "2.3.4": {"maintainer": "a@b.c", "make": "pip", "source": "pypi"},
+        "1.0.0": {"maintainer": "a@b.c", "make": "pip", "source": "pypi"},
+    },
+    "package_c": {
+        "0.0.1": {
+            "depends": ["package_d", "package_e"],
+            "maintainer": "a@b.c",
+            "make": "pip",
+            "source": "pypi",
+        }
+    },
+    "package_d": {
+        "10.2.1": {
+            "depends": ["package_e"],
+            "maintainer": "a@b.c",
+            "make": "pip",
+            "source": "pypi",
+        }
+    },
+    "package_e": {"4.1.2": {"maintainer": "a@b.c", "make": "pip", "source": "pypi"}},
+    "package_f": {
+        "0.1.2": {"maintainer": "a@b.c", "make": "pip", "source": "pypi"},
+        "1.0.2": {"maintainer": "a@b.c", "make": "pip", "source": "pypi"},
+    },
+}
+
+BASE_RELEASE = {
+    "package_a": "1.2.3",
+    "package_b": "2.3.4",
+    "package_c": "0.0.1",
+    "package_d": "10.2.1",
+    "package_e": "4.1.2",
+    "package_f": "1.0.2",
+}
+
+REPO_MISSING_PKG = {
+    "package_a": {
+        "1.2.3": {
+            "depends": ["package_b"],
+            "maintainer": "a@b.c",
+            "make": "pip",
+            "source": "pypi",
+        }
+    }
+}
+
+
+def test_extract_reverse_list():
+    rev_deps = reverse_dep_graph.build_reverse(BASE_RELEASE, REPO)
+    print(rev_deps)
+    assert len(rev_deps) == 5  # a does not have dependants
+    assert rev_deps["package_b"].difference({("package_a", "1.2.3")}) == set()
+    assert rev_deps["package_c"].difference({("package_a", "1.2.3")}) == set()
+    assert (
+        rev_deps["package_e"].difference(
+            {("package_c", "0.0.1"), ("package_d", "10.2.1"), ("package_a", "1.2.3")}
+        )
+        == set()
+    )
+    assert rev_deps["package_f"].difference({("package_a", "1.2.3")}) == set()
+    assert rev_deps["package_d"].difference({("package_c", "0.0.1")}) == set()
+
+
+def test_extract_missing_pkg_in_repo():
+    with pytest.raises(SystemExit) as exit_info:
+        reverse_dep_graph.build_reverse(BASE_RELEASE, REPO_MISSING_PKG)
+    assert "No package package_b in repo" in str(exit_info.value)
+
+
+def test_extract_reverse_graph():
+    rev_deps = reverse_dep_graph.build_reverse(BASE_RELEASE, REPO)
+    rev_dep_graph = reverse_dep_graph.reverse_deps("package_e", "4.1.2", rev_deps)
+    expected = {
+        "package_e-4.1.2": [
+            {"package_d-10.2.1": [{"package_c-0.0.1": [{"package_a-1.2.3": []}]}]},
+            {"package_c-0.0.1": [{"package_a-1.2.3": []}]},
+            {"package_a-1.2.3": []},
+        ]
+    }
+
+    assert _sort_graph(rev_dep_graph) == _sort_graph(expected)
+
+
+def _sort_graph(a):
+    for k, v in a.items():
+        v.sort(
+            key=lambda dep_graph: list(dep_graph.keys())[0]
+            if len(dep_graph) == 1
+            else ""
+        )
+        for sub_graph in v:
+            _sort_graph(sub_graph)


### PR DESCRIPTION
Can print a textual hierachical ascii thingy, or a dot graph description. Can also call "dot" and "display" to visualise the graph.
Example:
`python komodo/reverse_dep_graph.py releases/bleeding-py36.yml repository.yml --display_dot`