### PR TITLE
Download from pypi without deps

### DIFF
--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -53,6 +53,7 @@ def grab(path, filename = None, version = None, protocol = None,
 
     elif protocol in ('pypi'):
         shell([pip, 'download',
+                    '--no-deps',
                     '--dest .',
                     normalize_filename(komodo.strip_version(filename))])
 


### PR DESCRIPTION
No `--no-deps` has a bunch of disadvantages:

- though we only want to download the package in question, it downloads all deps, taking space and time
- our builds are most likely going to be affected by changes in the world, even between equal builds

This solves that