### PR TITLE
Lint release file names

### DIFF
--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -5,7 +5,6 @@ import os
 from .build import make, pypaths
 from .fetch import fetch
 from .shell import shell, pushd
-from .lint import lint
 from .prettier import prettier, load_yaml, write_to_file, prettified_yaml
 from .cleanup import cleanup
 from .maintainer import maintainers

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,39 +1,70 @@
-#!/usr/bin/env python
-from __future__ import print_function
+import pytest
+from komodo import lint
 
-import unittest
-import komodo
 
 REPO = {
-    'python': {
-        'v2.7.14': {
-            'maintainer': 'jokva@statoil.com',
-            'make': 'sh',
-            'makefile': 'configure',
-            'source': 'git://github.com/python/cpython.git'
+    "python": {
+        "v2.7.14": {
+            "maintainer": "jokva@statoil.com",
+            "make": "sh",
+            "makefile": "configure",
+            "source": "git://github.com/python/cpython.git",
         }
     },
-    'requests': {
-        '2.18.4': {
-            'depends': ['python'],
-            'maintainer': 'jokva@statoil.com',
-            'make': 'pip',
-            'source': 'pypi'
+    "requests": {
+        "2.18.4": {
+            "depends": ["python"],
+            "maintainer": "jokva@statoil.com",
+            "make": "pip",
+            "source": "pypi",
         }
     },
 }
 
 RELEASE = {
-    'python': 'v2.7.14',
-    'requests': '2.18.4',
+    "python": "v2.7.14",
+    "requests": "2.18.4",
 }
 
-class TestLint(unittest.TestCase):
 
-    def test_lint(self):
-        lint_report = komodo.lint(RELEASE, REPO)
-        self.assertEqual([], lint_report.dependencies)
-        self.assertEqual([], lint_report.versions)
+def test_lint():
+    lint_report = lint.lint(RELEASE, REPO)
+    assert [] == lint_report.dependencies
+    assert [] == lint_report.versions
 
-if __name__ == '__main__':
-    unittest.main()
+
+@pytest.mark.parametrize(
+    "valid",
+    (
+        "bleeding-py27.yml",
+        "bleeding-py36.yml",
+        "/home/anyuser/komodo-releases/releases/bleeding-py27.yml",
+        "/home/anyuser/komodo/bleeding-py27.yml",
+        "/home/anyuser/komodo/2020.01.03-py36-rhel6.yml",
+        "/home/anyuser/komodo/2020.01.03-py27.yml",
+        "myrelease-py27.yml",
+        "myrelease-py36.yml",
+        "myrelease-py27-rhel6.yml",
+        "myrelease-py27-rhel7.yml",
+        "myrelease-py36-rhel6.yml",
+        "myrelease-py36-rhel7.yml",
+    ),
+)
+def test_release_name_valid(valid):
+    assert lint.lint_release_name(valid) == []
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    (
+        "bleeding",
+        "bleeding.yml",
+        "2020.01.01",
+        "2020.01.00.yml",
+        "/home/anyuser/komodo-releases/releases/2020.01.00.yml",
+        "bleeding-py27",
+        "bleeding-rhel6.yml",
+    ),
+)
+def test_release_name_invalid(invalid):
+    assert lint.lint_release_name(invalid) != []


### PR DESCRIPTION
Resolves: #95 

Add linting that will check if a release name ends with one of: `-py27`, `-py36`, `-py27-rhel6`, `-py27-rhel7`, `-py36-rhel6`, `-py36-rhel7`.