### PR TITLE
Unset DESTDIR when pip install .

### DIFF
--- a/komodo/data/setup-py.sh
+++ b/komodo/data/setup-py.sh
@@ -51,6 +51,7 @@ while test $# -gt 0; do
     shift
 done
 
+unset DESTDIR
 $PIP install .           \
     --ignore-installed   \
     --root $FAKEROOT     \


### PR DESCRIPTION
DESTDIR is used by Komodo and other build packagers to compile the software when there is no access `/usr`. When installing Python packages, this is entirely superfluous, and actually breaks skbuild's build process, which gets incorrectly prefixed with the value of DESTDIR.