### PR TITLE
Add package_name field to pip_install

### DIFF
--- a/komodo/__init__.py
+++ b/komodo/__init__.py
@@ -1,78 +1,12 @@
 """Komodo software distribution build system."""
 
-import os
+__version__ = "1.0"
+__author__ = "Software Innovation Bergen, Statoil ASA"
 
-from .build import make, pypaths
-from .fetch import fetch
-from .shell import shell, pushd
-from .prettier import prettier, load_yaml, write_to_file, prettified_yaml
-from .cleanup import cleanup
-from .maintainer import maintainers
-
-
-def _is_shebang(s):
-    """Checks if the string potentially is a Python shebang."""
-    return s.startswith('#!/') and 'python' in s
-
-
-def fixup_python_shebangs(prefix, release):
-    """Fix shebang to $PREFIX/bin/python.
-
-    Some packages installed with pip do not respect target executable, that is,
-    they set as their shebang executable the Python executabl used to build the
-    komodo distribution with instead of the Python executable that komodo
-    deploys.  This breaks the application since the corresponding Python modules
-    won't be picked up correctly.
-
-    For now, we use sed to rewrite the first line in some executables.
-
-    This is a hack that should be fixed at some point.
-
-    """
-    binpath = os.path.join(prefix, release, 'root', 'bin')
-    if not os.path.isdir(binpath):
-        #No bin files to fix
-        return
-    python_ = os.path.join(binpath, 'python')
-
-    bins_ = []
-    # executables with wrong shebang
-    for bin_ in os.listdir(binpath):
-        try:
-            with open(os.path.join(binpath, bin_), 'r') as f:
-                shebang = f.readline().strip()
-            if _is_shebang(shebang):
-                bins_.append(bin_)
-        except Exception as err:
-            print('Exception in reading bin {}: {}'.format(bin_, err))
-
-    sedfxp = """sed -i 1c#!{0} {1}"""
-    for bin_ in bins_:
-        binpath_ = os.path.join(prefix, release, 'root', 'bin', bin_)
-        if os.path.exists(binpath_):
-            shell(sedfxp.format(python_, binpath_))
-
-def strip_version(version):
-    """
-    In order to be able to support both py2 and py3 we need to be able
-    to have multiple versions of the same package/version due to
-    differences in dependencies. This is achieved by adding i.e '+py3'
-    to a version-spec in both the release and repository file. This func
-    strips the '+' and everything behind for all pip packages so we are 
-    able to install.
-    """
-    return version.split("+")[0]
-
-
-__version__ = '1.0'
-__author__ = 'Software Innovation Bergen, Statoil ASA'
-
-__copyright__ = 'Copyright 2017, Statoil ASA'
-__license__ = 'GNU General Public License, version 3 or any later version'
+__copyright__ = "Copyright 2017, Statoil ASA"
+__license__ = "GNU General Public License, version 3 or any later version"
 
 __credits__ = __author__
 __maintainer__ = __author__
-__email__ = 'fg_gpl@statoil.com'
-__status__ = 'Production'
-
-__ALL__ = ['make', 'fetch', 'shell', 'lint', 'maintainers']
+__email__ = "fg_gpl@statoil.com"
+__status__ = "Production"

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -7,9 +7,8 @@ import os
 import sys
 from distutils.dir_util import mkpath
 
-import komodo
-
-from .shell import pushd, shell
+from komodo.package_version import strip_version
+from komodo.shell import pushd, shell
 
 flatten = itr.chain.from_iterable
 
@@ -107,20 +106,28 @@ def sh(pkg, ver, pkgpath, data, prefix, makefile, *args, **kwargs):
 def rsync(pkg, ver, pkgpath, data, prefix, *args, **kwargs):
     print('Installing {} ({}) with rsync'.format(pkg, ver))
     # assume a root-like layout in the pkgpath dir, and just copy it
-    shell(['rsync -am', kwargs.get('makeopts'), '{}/'.format(pkgpath), kwargs['fakeroot'] + prefix])
+    shell(
+        [
+            "rsync -am",
+            kwargs.get("makeopts"),
+            "{}/".format(pkgpath),
+            kwargs["fakeroot"] + prefix,
+        ]
+    )
 
 
-def pip_install(pkg, ver, pkgpath, data, prefix, dlprefix, pip='pip', *args, **kwargs):
-    cmd = [pip,
-           'install {}=={}'.format(pkg, komodo.strip_version(ver)),
-           '--root {}'.format(kwargs['fakeroot']),
-           '--prefix {}'.format(prefix),
-           '--no-index',
-           '--no-deps',
-           '--ignore-installed',
-           '--cache-dir {}'.format(dlprefix),
-           '--find-links {}'.format(dlprefix),
-           kwargs.get('makeopts', ''),
+def pip_install(pkg, ver, pkgpath, data, prefix, dlprefix, pip="pip", *args, **kwargs):
+    cmd = [
+        pip,
+        "install {}=={}".format(pkg, strip_version(ver)),
+        "--root {}".format(kwargs["fakeroot"]),
+        "--prefix {}".format(prefix),
+        "--no-index",
+        "--no-deps",
+        "--ignore-installed",
+        "--cache-dir {}".format(dlprefix),
+        "--find-links {}".format(dlprefix),
+        kwargs.get("makeopts", ""),
     ]
 
     print('Installing {} ({}) from pip'.format(pkg, ver))

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -197,23 +197,32 @@ def make(pkgfile, repofile, data,
         current = repo[pkg][ver]
         make = current['make']
         pkgpath = os.path.abspath(path)
+        if "pypi_package_name" in current and make != "pip":
+            raise ValueError("pypi_package_name is only valid when building with pip")
+
+        package_name = current.get("pypi_package_name", pkg)
 
         if extra_makeopts:
-            oldopts = current.get('makeopts', '')
-            current['makeopts'] = ' '.join((oldopts, extra_makeopts))
+            oldopts = current.get("makeopts", "")
+            current["makeopts"] = " ".join((oldopts, extra_makeopts))
 
-        current['makeopts'] = resolve(current.get('makeopts', ''))
-        build[make](pkg, ver, pkgpath, data,
-                    prefix=prefix,
-                    builddir=builddir,
-                    makeopts=current.get('makeopts'),
-                    makefile=current.get('makefile'),
-                    dlprefix=dlprefix if dlprefix else '.',
-                    jobs=jobs,
-                    cmake=cmk,
-                    pip=pip,
-                    virtualenv=virtualenv,
-                    fakeroot=fakeroot,
-                    pythonpath=build_pythonpath,
-                    binpath=build_path,
-                    ld_lib_path=build_ld_lib_path,)
+        current["makeopts"] = resolve(current.get("makeopts", ""))
+        build[make](
+            package_name,
+            ver,
+            pkgpath,
+            data,
+            prefix=prefix,
+            builddir=builddir,
+            makeopts=current.get("makeopts"),
+            makefile=current.get("makefile"),
+            dlprefix=dlprefix if dlprefix else ".",
+            jobs=jobs,
+            cmake=cmk,
+            pip=pip,
+            virtualenv=virtualenv,
+            fakeroot=fakeroot,
+            pythonpath=build_pythonpath,
+            binpath=build_path,
+            ld_lib_path=build_ld_lib_path,
+        )

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -2,19 +2,14 @@
 
 from __future__ import print_function
 
-import argparse
-from distutils.dir_util import mkpath
 import itertools as itr
 import os
-import subprocess
 import sys
-import yaml as yml
+from distutils.dir_util import mkpath
+
 import komodo
-import sys
 
-from .shell import shell, pushd
-from komodo.data import Data
-
+from .shell import pushd, shell
 
 flatten = itr.chain.from_iterable
 
@@ -145,17 +140,19 @@ def pypaths(prefix, version):
                       '{0}/lib64/{1}/site-packages'.format(prefix, pyver) ])
 
 
-def make(pkgfile, repofile, data,
-         prefix=None,
-         dlprefix=None,
-         builddir=None,
-         jobs=1,
-         cmk='cmake',
-         pip='pip',
-         virtualenv=None,
-         fakeroot='.',):
-    with open(pkgfile) as p, open(repofile) as r:
-        pkgs, repo = yml.safe_load(p), yml.safe_load(r)
+def make(
+    pkgs,
+    repo,
+    data,
+    prefix,
+    dlprefix=None,
+    builddir=None,
+    jobs=1,
+    cmk="cmake",
+    pip="pip",
+    virtualenv=None,
+    fakeroot=".",
+):
 
     xs = flatten(dfs(pkg, ver, pkgs, repo) for pkg, ver in pkgs.items())
 

--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -121,12 +121,14 @@ def _main(args):
     release_path = os.path.join(args.prefix, args.release)
     release_root = os.path.join(release_path, "root")
     for pkg, ver in pkgs.items():
-        if repo[pkg][ver]["make"] != "pip":
+        current = repo[pkg][ver]
+        if current["make"] != "pip":
             continue
 
+        package_name = current.get("pypi_package_name", pkg)
         shell_input = [
             args.pip,
-            "install {}=={}".format(pkg, komodo.strip_version(ver)),
+            "install {}=={}".format(package_name, komodo.strip_version(ver)),
             "--prefix",
             release_root,
             "--no-index",
@@ -135,7 +137,7 @@ def _main(args):
             "--cache-dir {}".format(args.cache),
             "--find-links {}".format(args.cache),
         ]
-        shell_input.append(repo[pkg][ver].get("makeopts"))
+        shell_input.append(current.get("makeopts"))
 
         print(komodo.shell(shell_input, sudo=args.sudo))
 

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -5,8 +5,9 @@ from __future__ import print_function
 import argparse
 import os
 import sys
-import yaml as yml
+
 import komodo
+from komodo.yaml_file_type import YamlFile
 
 from .shell import shell, pushd
 
@@ -52,10 +53,7 @@ def grab(path, filename = None, version = None, protocol = None,
         raise NotImplementedError('Unknown protocol {}'.format(protocol))
 
 
-def fetch(pkgfile, repofile, outdir = '.', pip = 'pip', git = 'git'):
-    with open(pkgfile) as p, open(repofile) as r:
-        pkgs, repo = yml.safe_load(p), yml.safe_load(r)
-
+def fetch(pkgs, repo, outdir=".", pip="pip", git="git"):
     missingpkg = [pkg for pkg in pkgs if pkg not in repo]
     missingver = [pkg for pkg, ver in pkgs.items()
                                    if pkg in repo and ver not in repo[pkg]]
@@ -132,13 +130,13 @@ def fetch(pkgfile, repofile, outdir = '.', pip = 'pip', git = 'git'):
         shell([pip, 'download', '--no-deps', '--dest .', " ".join(pypi_packages)])
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description = 'fetch packages')
-    parser.add_argument('pkgfile',  type=str)
-    parser.add_argument('repofile', type=str)
-    parser.add_argument('--output', '-o', type=str)
-    parser.add_argument('--pip', type=str, default = 'pip')
-    parser.add_argument('--git', type=str, default = 'git')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="fetch packages")
+    parser.add_argument("pkgfile", type=YamlFile())
+    parser.add_argument("repofile", type=YamlFile())
+    parser.add_argument("--output", "-o", type=str)
+    parser.add_argument("--pip", type=str, default="pip")
+    parser.add_argument("--git", type=str, default="git")
     args = parser.parse_args()
     fetch(args.pkgfile, args.repofile, outdir = args.output,
                                        pip = args.pip,

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -6,10 +6,9 @@ import argparse
 import os
 import sys
 
-import komodo
+from komodo.package_version import strip_version
+from komodo.shell import pushd, shell
 from komodo.yaml_file_type import YamlFile
-
-from .shell import shell, pushd
 
 
 def eprint(*args, **kwargs):
@@ -33,12 +32,17 @@ def grab(path, filename = None, version = None, protocol = None,
         shell('wget --quiet {} -O {}'.format(path, filename))
     elif protocol in ('git'):
         shell(
-            '{git} clone '
-            '--depth 50 '
-            '-b {version} '
-            '-q --recursive '
-            '-- {path} {filename}'
-            ''.format(git=git, version=komodo.strip_version(version), path=path, filename=filename)
+            "{git} clone "
+            "--depth 50 "
+            "-b {version} "
+            "-q --recursive "
+            "-- {path} {filename}"
+            "".format(
+                git=git,
+                version=strip_version(version),
+                path=path,
+                filename=filename,
+            )
         )
 
     elif protocol in ('nfs', 'fs-ln'):
@@ -107,9 +111,9 @@ def fetch(pkgs, repo, outdir=".", pip="pip", git="git"):
             if ext in ['rpm', 'tar', 'gz', 'tgz', 'tar.gz', 'tar.bz2', 'tar.xz']:
                 dst = '{}.{}'.format(dst, ext)
 
-            if url == 'pypi':
-                print('Defering download of {}'.format(name))
-                pypi_packages.append(normalize_filename(komodo.strip_version(dst)))
+            if url == "pypi":
+                print("Defering download of {}".format(name))
+                pypi_packages.append(normalize_filename(strip_version(dst)))
                 continue
 
             print('Downloading {}'.format(name))

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -79,11 +79,18 @@ def fetch(pkgfile, repofile, outdir = '.', pip = 'pip', git = 'git'):
 
     with pushd(outdir):
         for pkg, ver in pkgs.items():
-            print(pkg, ver)
-            url = repo[pkg][ver].get('source')
-            protocol = repo[pkg][ver].get('fetch')
-            name = '{} ({}): {}'.format(pkg, ver, url)
-            pkgname = '{}-{}'.format(pkg, ver)
+
+            current = repo[pkg][ver]
+            if "pypi_package_name" in current and current["make"] != "pip":
+                raise ValueError(
+                    "pypi_package_name is only valid when building with pip"
+                )
+
+            url = current.get("source")
+            protocol = current.get("fetch")
+            pkg_alias = current.get("pypi_package_name", pkg)
+            name = "{} ({}): {}".format(pkg_alias, ver, url)
+            pkgname = "{}-{}".format(pkg_alias, ver)
 
             if url is None and protocol is None:
                 package_folder = os.path.abspath(pkgname)

--- a/komodo/lint_package_status.py
+++ b/komodo/lint_package_status.py
@@ -6,6 +6,7 @@ import sys
 
 import yaml
 
+from komodo.yaml_file_type import YamlFile
 
 VALID_VISIBILITY = ["public", "private"]
 VALID_IMPORTANCE = ["low", "medium", "high"]
@@ -59,16 +60,12 @@ def get_parser():
     parser = argparse.ArgumentParser(description=("Lint the package status file."))
     parser.add_argument(
         "package_status",
-        type=lambda arg: arg
-        if os.path.isfile(arg)
-        else parser.error("{} is not a file".format(arg)),
+        type=YamlFile(),
         help="File with all package statuses.",
     )
     parser.add_argument(
         "repository",
-        type=lambda arg: arg
-        if os.path.isfile(arg)
-        else parser.error("{} is not a file".format(arg)),
+        type=YamlFile(),
         help="Repository file with all packages listed with dependencies.",
     )
     return parser
@@ -78,13 +75,9 @@ def main():
     parser = get_parser()
     args = parser.parse_args()
 
-    with open(args.package_status) as ps, open(args.repository) as r:
-        package_status, repository = yaml.safe_load(ps), yaml.safe_load(r)
-
-    run(package_status, repository)
+    run(args.package_status, args.repository)
     print("Package status file is valid!")
 
 
 if __name__ == "__main__":
     main()
-

--- a/komodo/package_version.py
+++ b/komodo/package_version.py
@@ -1,0 +1,10 @@
+def strip_version(version):
+    """
+    In order to be able to support both py2 and py3 we need to be able
+    to have multiple versions of the same package/version due to
+    differences in dependencies. This is achieved by adding i.e '+py3'
+    to a version-spec in both the release and repository file. This func
+    strips the '+' and everything behind for all pip packages so we are
+    able to install.
+    """
+    return version.split("+")[0]

--- a/komodo/release_cleanup.py
+++ b/komodo/release_cleanup.py
@@ -1,8 +1,8 @@
 import os
 import sys
 from argparse import ArgumentError, ArgumentParser, ArgumentTypeError
-from komodo import load_yaml, write_to_file, prettified_yaml
-from komodo.prettier import prettier
+
+from komodo.prettier import load_yaml, prettier, prettified_yaml, write_to_file
 
 
 def load_all_releases(files):

--- a/komodo/release_transpiler.py
+++ b/komodo/release_transpiler.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python
 
 import argparse
-import os
 import itertools
-from argparse import ArgumentError, ArgumentParser, ArgumentTypeError, RawTextHelpFormatter
-from komodo import load_yaml, write_to_file, prettified_yaml
-from komodo.matrix import get_matrix, format_release
+import os
+from argparse import (
+    ArgumentError,
+    ArgumentParser,
+    ArgumentTypeError,
+    RawTextHelpFormatter,
+)
+
+from komodo.matrix import format_release, get_matrix
+from komodo.prettier import load_yaml, write_to_file
 
 
 def build_matrix_file(release_base, release_folder, builtins):

--- a/komodo/shebang.py
+++ b/komodo/shebang.py
@@ -1,0 +1,46 @@
+import os
+
+from komodo.shell import shell
+
+
+def _is_shebang(s):
+    """Checks if the string potentially is a Python shebang."""
+    return s.startswith("#!/") and "python" in s
+
+
+def fixup_python_shebangs(prefix, release):
+    """Fix shebang to $PREFIX/bin/python.
+
+    Some packages installed with pip do not respect target executable, that is,
+    they set as their shebang executable the Python executabl used to build the
+    komodo distribution with instead of the Python executable that komodo
+    deploys.  This breaks the application since the corresponding Python modules
+    won't be picked up correctly.
+
+    For now, we use sed to rewrite the first line in some executables.
+
+    This is a hack that should be fixed at some point.
+
+    """
+    binpath = os.path.join(prefix, release, "root", "bin")
+    if not os.path.isdir(binpath):
+        # No bin files to fix
+        return
+    python_ = os.path.join(binpath, "python")
+
+    bins_ = []
+    # executables with wrong shebang
+    for bin_ in os.listdir(binpath):
+        try:
+            with open(os.path.join(binpath, bin_), "r") as f:
+                shebang = f.readline().strip()
+            if _is_shebang(shebang):
+                bins_.append(bin_)
+        except Exception as err:
+            print("Exception in reading bin {}: {}".format(bin_, err))
+
+    sedfxp = """sed -i 1c#!{0} {1}"""
+    for bin_ in bins_:
+        binpath_ = os.path.join(prefix, release, "root", "bin", bin_)
+        if os.path.exists(binpath_):
+            shell(sedfxp.format(python_, binpath_))

--- a/komodo/yaml_file_type.py
+++ b/komodo/yaml_file_type.py
@@ -1,0 +1,14 @@
+import argparse
+
+import yaml as yml
+
+
+class YamlFile(argparse.FileType):
+    def __init__(self, *args, **kwargs):
+        super().__init__("r", *args, **kwargs)
+
+    def __call__(self, value):
+        file_handle = super().__call__(value)
+        yaml = yml.safe_load(file_handle)
+        file_handle.close()
+        return yaml

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,77 @@
+import pytest
+
+from komodo.build import make
+
+
+@pytest.fixture
+def captured_shell_commands(monkeypatch):
+    commands = []
+    with monkeypatch.context() as m:
+        m.setattr("komodo.build.shell", lambda cmd: commands.append(cmd))
+        yield commands
+
+
+def test_make_with_empty_pkgs(captured_shell_commands, tmpdir):
+    make({}, {}, {}, str(tmpdir))
+    assert len(captured_shell_commands) == 1
+    assert "mkdir" in " ".join(captured_shell_commands[0])
+
+
+def test_make_one_pip_package(captured_shell_commands, tmpdir):
+    packages = {"pyaml": "20.4.0"}
+    repositories = {
+        "pyaml": {
+            "20.4.0": {
+                "source": "pypi",
+                "make": "pip",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+
+    make(packages, repositories, {}, str(tmpdir))
+
+    assert len(captured_shell_commands) == 2
+    assert "mkdir" in " ".join(captured_shell_commands[0])
+    assert "pip install pyaml" in " ".join(captured_shell_commands[1])
+
+
+def test_make_one_pip_package_different_name(captured_shell_commands, tmpdir):
+    packages = {"yaml": "20.4.0"}
+    repositories = {
+        "yaml": {
+            "20.4.0": {
+                "source": "pypi",
+                "pypi_package_name": "PyYaml",
+                "make": "pip",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+
+    make(packages, repositories, {}, str(tmpdir))
+
+    assert len(captured_shell_commands) == 2
+    assert "mkdir" in " ".join(captured_shell_commands[0])
+    assert "pip install PyYaml==20.4.0" in " ".join(captured_shell_commands[1])
+
+
+def test_make_sh_does_not_accept_pypi_package_name(captured_shell_commands, tmpdir):
+    packages = {"ert": "2.16.0"}
+    repositories = {
+        "ert": {
+            "2.16.0": {
+                "source": "git://github.com/equinor/ert.git",
+                "pypi_package_name": "some-other-name",
+                "fetch": "git",
+                "make": "sh",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="pypi_package_name"):
+        make(packages, repositories, {}, str(tmpdir))

--- a/tests/test_enable_scipts.py
+++ b/tests/test_enable_scipts.py
@@ -1,7 +1,8 @@
-import komodo
-import os
 import json
+import os
+
 from komodo.data import Data
+from komodo.shell import shell
 
 
 def _create_script(kmd_prefix, kmd_pyver, kmd_release, target, template):
@@ -9,7 +10,7 @@ def _create_script(kmd_prefix, kmd_pyver, kmd_release, target, template):
     os.mkdir(kmd_release)
     with open("{}/{}".format(kmd_release, target), "w") as f:
         f.write(
-            komodo.shell(
+            shell(
                 [
                     "m4 {}".format(data.get("enable.m4")),
                     "-D komodo_prefix={}".format(kmd_prefix),
@@ -61,7 +62,7 @@ def test_enable_bash_nopresets(tmpdir):
                 )
             )
 
-        komodo.shell(["bash test_enable.sh"])
+        shell(["bash test_enable.sh"])
         pre_env, sourced_env, post_env = _load_envs()
 
         assert "LD_LIBRARY_PATH" not in pre_env
@@ -92,7 +93,7 @@ def test_enable_csh_no_presets(tmpdir):
                 )
             )
 
-        komodo.shell(["csh test_enable.sh"])
+        shell(["csh test_enable.sh"])
         pre_env, sourced_env, post_env = _load_envs()
 
         assert "LD_LIBRARY_PATH" not in pre_env
@@ -121,7 +122,7 @@ def test_enable_bash_with_presets(tmpdir):
                 )
             )
 
-        komodo.shell(["bash test_enable.sh"])
+        shell(["bash test_enable.sh"])
         pre_env, sourced_env, post_env = _load_envs()
         assert pre_env["LD_LIBRARY_PATH"] == "/some/path"
         assert sourced_env["LD_LIBRARY_PATH"] == "prefix/lib:prefix/lib64:/some/path"
@@ -151,7 +152,7 @@ def test_enable_csh_with_presets(tmpdir):
                 )
             )
 
-        komodo.shell(["csh test_enable.sh"])
+        shell(["csh test_enable.sh"])
         pre_env, sourced_env, post_env = _load_envs()
 
         assert pre_env["LD_LIBRARY_PATH"] == "/some/path"

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,76 @@
+import pytest
+
+from komodo.fetch import fetch
+
+
+@pytest.fixture
+def captured_shell_commands(monkeypatch):
+    commands = []
+    with monkeypatch.context() as m:
+        m.setattr("komodo.fetch.shell", lambda cmd: commands.append(cmd))
+        yield commands
+
+
+def test_make_one_pip_package(captured_shell_commands, tmpdir):
+    packages = {"pyaml": "20.4.0"}
+    repositories = {
+        "pyaml": {
+            "20.4.0": {
+                "source": "pypi",
+                "make": "pip",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+
+    fetch(packages, repositories, str(tmpdir))
+
+    assert len(captured_shell_commands) == 1
+
+    command = " ".join(captured_shell_commands[0])
+
+    assert command.startswith("pip download")
+    assert "pyaml" in command
+
+
+def test_fetch_with_empty_pypi_package_name(captured_shell_commands, tmpdir):
+    packages = {"yaml": "20.4.0"}
+    repositories = {
+        "yaml": {
+            "20.4.0": {
+                "source": "pypi",
+                "pypi_package_name": "PyYaml",
+                "make": "pip",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+    fetch(packages, repositories, str(tmpdir))
+
+    assert len(captured_shell_commands) == 1
+
+    command = " ".join(captured_shell_commands[0])
+
+    assert command.startswith("pip download")
+    assert "PyYaml" in command
+
+
+def test_fetch_git_does_not_accept_pypi_package_name(captured_shell_commands, tmpdir):
+    packages = {"ert": "2.16.0"}
+    repositories = {
+        "ert": {
+            "2.16.0": {
+                "source": "git://github.com/equinor/ert.git",
+                "pypi_package_name": "some-other-name",
+                "fetch": "git",
+                "make": "sh",
+                "maintainer": "someone",
+                "depends": [],
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="pypi_package_name"):
+        fetch(packages, repositories, str(tmpdir))

--- a/tests/test_komodo.py
+++ b/tests/test_komodo.py
@@ -1,6 +1,9 @@
-import pytest  # noqa
 import os
+
+import pytest  # noqa
+
 import komodo
+from komodo.shebang import fixup_python_shebangs
 
 
 def test_fixup_python_shebangs(tmpdir):
@@ -12,7 +15,7 @@ def test_fixup_python_shebangs(tmpdir):
     with open(os.path.join(bindir, "bad_shebang"), "w") as f:
         f.write("#!/wildly/wrong/path/to\xe7\x8e\xa9/python\n")
 
-    komodo.fixup_python_shebangs(prefix, "release")
+    fixup_python_shebangs(prefix, "release")
 
     target = "#!{}".format(os.path.join(bindir, "python\n"))
     with open(os.path.join(bindir, "bad_shebang")) as f:

--- a/tests/test_prettier.py
+++ b/tests/test_prettier.py
@@ -5,8 +5,7 @@ import unittest
 
 from ruamel.yaml.constructor import DuplicateKeyError
 
-import komodo
-
+from komodo.prettier import load_yaml, prettier
 
 INPUT_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "input")
 
@@ -20,30 +19,24 @@ class TestPrettier(unittest.TestCase):
     def test_repository_prettifying(self):
         pretty_repository = TestPrettier.get_yaml_string("pretty_repository.yml")
         self.assertEqual(
-            komodo.prettier(
-                komodo.load_yaml(os.path.join(INPUT_FOLDER, "ugly_repository.yml"))
-            ),
+            prettier(load_yaml(os.path.join(INPUT_FOLDER, "ugly_repository.yml"))),
             pretty_repository,
         )
 
     def test_release_prettifying(self):
         pretty_release = TestPrettier.get_yaml_string("pretty_release.yml")
         self.assertEqual(
-            komodo.prettier(
-                komodo.load_yaml(os.path.join(INPUT_FOLDER, "ugly_release.yml"))
-            ),
+            prettier(load_yaml(os.path.join(INPUT_FOLDER, "ugly_release.yml"))),
             pretty_release,
         )
 
     def test_duplicate_entries(self):
         with self.assertRaises(SystemExit):
-            komodo.load_yaml(os.path.join(INPUT_FOLDER, "duplicate_repository.yml"))
+            load_yaml(os.path.join(INPUT_FOLDER, "duplicate_repository.yml"))
 
     def test_inconsistent_config(self):
         with self.assertRaises(ValueError):
-            komodo.prettier(
-                komodo.load_yaml(os.path.join(INPUT_FOLDER, "inconsistent_config.yml"))
-            )
+            prettier(load_yaml(os.path.join(INPUT_FOLDER, "inconsistent_config.yml")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement the repository field "pypi_package_name" to specify name of a package in pypi when installing via `pip_install`.
