### PR TITLE
Fix no testKomodo

### DIFF
--- a/vars/testKomodo.groovy
+++ b/vars/testKomodo.groovy
@@ -137,7 +137,9 @@ def call(Map args = [:]) {
 
                         set -x
                         git log -n 1
-                        source ${env.CI_SOURCE_ROOT}/ci/jenkins/testkomodo.sh
+                        if [ -f "${env.CI_SOURCE_ROOT}/ci/jenkins/testkomodo.sh" ]; then
+                            source ${env.CI_SOURCE_ROOT}/ci/jenkins/testkomodo.sh
+                        fi
                         git log -n 1
                         run_tests
                     """

--- a/vars/testKomodo.groovy
+++ b/vars/testKomodo.groovy
@@ -136,7 +136,6 @@ def call(Map args = [:]) {
                         source ${env.WORKSPACE}/ci_helper.sh
 
                         set -x
-                        git log -n 1
                         if [ -f "${env.CI_SOURCE_ROOT}/ci/jenkins/testkomodo.sh" ]; then
                             source ${env.CI_SOURCE_ROOT}/ci/jenkins/testkomodo.sh
                         fi


### PR DESCRIPTION
In case `ci_helper.sh` works without changes, it should be possible to allow `testKomodo.sh` not to exist.