### PR TITLE
Disable dependency tracking when building ncdu

### DIFF
--- a/komodo/data/build__ncdu.sh
+++ b/komodo/data/build__ncdu.sh
@@ -31,6 +31,6 @@ done
 
 
 export CFLAGS="-ltinfo"
-./configure --prefix=$PREFIX
+./configure --disable-dependency-tracking --prefix=$PREFIX
 make
 make install


### PR DESCRIPTION
Get the following error when building `ncdu`:

```
Installing ncdu (v1.15.1) from sh
[/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/cache/ncdu-1.15.1]> bash /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo/boot/kmd-env/lib64/python3.6/site-packages/komodo/data/build__ncdu.sh --prefix /prog/res/komodo/2021.01.rc0-py36-rhel7/root --fakeroot /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7 --python /prog/res/komodo/2021.01.rc0-py36-rhel7/root/bin/python --jobs 6 --cmake cmake --pythonpath /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/lib/python3.6:/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/lib/python3.6/site-packages:/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/lib64/python3.6/site-packages --path /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/bin:/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo/boot/bintools:/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo/boot/build-env/bin:/usr/local/bin:/usr/bin:/global/distbin:/global/bin:/global/SP/bin --pip /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo/boot/build-env/bin/pip --virtualenv /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo/boot/kmd-env/bin/virtualenv --ld-library-path /tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/lib:/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/2021.01.rc0-py36-rhel7/prog/res/komodo/2021.01.rc0-py36-rhel7/root/lib64config.status: error: in `/tmp/jenkins-komodo-f_komodo/workspace/x-build-some-other/2021.01.rc0-py36-rhel7/komodo-releases/cache/ncdu-1.15.1':
config.status: error: Something went wrong bootstrapping makefile fragments
    for automatic dependency tracking.  Try re-running configure with the
    '--disable-dependency-tracking' option to at least be able to build
    the package (albeit without support for automatic dependency tracking).
See `config.log' for more details
b'checking for a BSD-compatible install... /usr/bin/install -c\nchecking whether build environment is sane... yes\nchecking for a thread-safe mkdir -p... /usr/bin/mkdir -p\nchecking for gawk... gawk\nchecking whether make sets $(MAKE)... yes\nchecking whether make supports nested variables... no\nchecking for gcc... gcc\nchecking whether the C compiler works... yes\nchecking for C compiler default output file name... a.out\nchecking for suffix of executables... \nchecking whether we are cross compiling... no\nchecking for suffix of object files... o\nchecking whether we are using the GNU C compiler... yes\nchecking whether gcc accepts -g... yes\nchecking for gcc option to accept ISO C89... none needed\nchecking whether gcc understands -c and -o together... yes\nchecking whether make supports the include directive... yes (GNU style)\nchecking dependency style of gcc... gcc3\nchecking for ranlib... ranlib\nchecking for pkg-config... /usr/bin/pkg-config\nchecking pkg-config is at least version 0.9.0... yes\nchecking how to run the C preprocessor... gcc -E\nchecking for grep that handles long lines and -e... /usr/bin/grep\nchecking for egrep... /usr/bin/grep -E\nchecking for ANSI C header files... yes\nchecking for sys/types.h... yes\nchecking for sys/stat.h... yes\nchecking for stdlib.h... yes\nchecking for string.h... yes\nchecking for memory.h... yes\nchecking for strings.h... yes\nchecking for inttypes.h... yes\nchecking for stdint.h... yes\nchecking for unistd.h... yes\nchecking limits.h usability... yes\nchecking limits.h presence... yes\nchecking for limits.h... yes\nchecking sys/time.h usability... yes\nchecking sys/time.h presence... yes\nchecking for sys/time.h... yes\nchecking for sys/types.h... (cached) yes\nchecking for sys/stat.h... (cached) yes\nchecking dirent.h usability... yes\nchecking dirent.h presence... yes\nchecking for dirent.h... yes\nchecking for unistd.h... (cached) yes\nchecking fnmatch.h usability... yes\nchecking fnmatch.h presence... yes\nchecking for fnmatch.h... yes\nchecking ncurses.h usability... yes\nchecking ncurses.h presence... yes\nchecking for ncurses.h... yes\nchecking locale.h usability... yes\nchecking locale.h presence... yes\nchecking for locale.h... yes\nchecking sys/statfs.h usability... yes\nchecking sys/statfs.h presence... yes\nchecking for sys/statfs.h... yes\nchecking linux/magic.h usability... yes\nchecking linux/magic.h presence... yes\nchecking for linux/magic.h... yes\nchecking for int64_t... yes\nchecking for uint64_t... yes\nchecking for special C compiler options needed for large files... no\nchecking for _FILE_OFFSET_BITS value needed for large files... no\nchecking for struct stat.st_blocks... yes\nchecking for getcwd... yes\nchecking for gettimeofday... yes\nchecking for fnmatch... yes\nchecking for chdir... yes\nchecking for rmdir... yes\nchecking for unlink... yes\nchecking for lstat... yes\nchecking for system... yes\nchecking for getenv... yes\nchecking for statfs... yes\nchecking sys/attr.h usability... no\nchecking sys/attr.h presence... no\nchecking for sys/attr.h... no\nchecking for getattrlist... no\nchecking whether ATTR_CMNEXT_NOFIRMLINKPATH is declared... no\nchecking for ncursesw... yes\nconfigure: Using /bin/sh as the default shell if $SHELL is not set\nchecking that generated files are newer than configure... done\nconfigure: creating ./config.status\nconfig.status: creating Makefile\nconfig.status: creating config.h\nconfig.status: executing depfiles commands\n'
```

I suggest that we disable dependency tracking as the error message suggests... I see that homebrew also does the same in its recipe for `ncdu`: https://github.com/Homebrew/homebrew-core/blob/0557c9fbf41b50e19ac85ef76a595068f98a552a/Formula/ncdu.rb#L27