### PR TITLE
csh: Use $_PRE_KOMODO_PS1 instead of $prompt

### DIFF
--- a/komodo/data/activator_switch.csh.tmpl
+++ b/komodo/data/activator_switch.csh.tmpl
@@ -4,7 +4,7 @@ if ( `uname -r` =~ *el7* ) then
 
     source $KOMODO_ROOT/$KOMODO_RELEASE_REAL-rhel7/enable.csh
     if ( $?prompt ) then
-        set prompt = "[$KOMODO_RELEASE_REAL] $prompt"
+        set prompt = "[$KOMODO_RELEASE_REAL] $_PRE_KOMODO_PS1"
     endif
     setenv KOMODO_RELEASE $KOMODO_RELEASE_REAL
 else

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -43,7 +43,7 @@ fi
 
     source $KOMODO_ROOT/$KOMODO_RELEASE_REAL-rhel7/enable.csh
     if ( $?prompt ) then
-        set prompt = "[$KOMODO_RELEASE_REAL] $prompt"
+        set prompt = "[$KOMODO_RELEASE_REAL] $_PRE_KOMODO_PS1"
     endif
     setenv KOMODO_RELEASE $KOMODO_RELEASE_REAL
 else


### PR DESCRIPTION
Using $prompt here causes the komodo release version to double up in the user's
PS1. The bash version of this uses $_PRE_KOMODO_PS1 and so should the csh
version.

Resolves: #181