### PR TITLE
csh: It's called $_KOMODO_OLD_PROMPT

### DIFF
--- a/komodo/data/activator_switch.csh.tmpl
+++ b/komodo/data/activator_switch.csh.tmpl
@@ -3,8 +3,8 @@ if ( `uname -r` =~ *el7* ) then
     set KOMODO_RELEASE_REAL = "{{ release }}"
 
     source $KOMODO_ROOT/$KOMODO_RELEASE_REAL-rhel7/enable.csh
-    if ( $?prompt ) then
-        set prompt = "[$KOMODO_RELEASE_REAL] $_PRE_KOMODO_PS1"
+    if ( $?_KOMODO_OLD_PROMPT ) then
+        set prompt = "[$KOMODO_RELEASE_REAL] $_KOMODO_OLD_PROMPT"
     endif
     setenv KOMODO_RELEASE $KOMODO_RELEASE_REAL
 else

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -42,8 +42,8 @@ fi
     set KOMODO_RELEASE_REAL = "{release}"
 
     source $KOMODO_ROOT/$KOMODO_RELEASE_REAL-rhel7/enable.csh
-    if ( $?prompt ) then
-        set prompt = "[$KOMODO_RELEASE_REAL] $_PRE_KOMODO_PS1"
+    if ( $?_KOMODO_OLD_PROMPT ) then
+        set prompt = "[$KOMODO_RELEASE_REAL] $_KOMODO_OLD_PROMPT"
     endif
     setenv KOMODO_RELEASE $KOMODO_RELEASE_REAL
 else


### PR DESCRIPTION
The enable.csh file defines `$_KOMODO_OLD_PROMPT` rather than `$_PRE_KOMODO_PS1` for whatever reason. :sweat: 

https://github.com/equinor/komodo/blob/a84813ee904a24cb9ed93275671f2cb6c320c13a/komodo/data/enable.csh.in#L51