### PR TITLE
Add --no-update to komodoenv command

### DIFF
--- a/vars/testKomodo.groovy
+++ b/vars/testKomodo.groovy
@@ -76,7 +76,7 @@ def call(Map args = [:]) {
                     sh 'komodoenv-venv/bin/pip install git+https://github.com/equinor/komodoenv.git'
 
                     // Use komodoenv to generate a komodoenv
-                    sh "komodoenv-venv/bin/komodoenv -r${env.CI_KOMODO_RELEASE} test-kenv"
+                    sh "komodoenv-venv/bin/komodoenv -r${env.CI_KOMODO_RELEASE} --no-update test-kenv"
 
                     // Git clone
                     script {


### PR DESCRIPTION
After `komodoenv` v0.3 has a `--no-update` option for releases that are not
meant to be updated, ie. singular releases.

As the komodo integration tests are usually run on non-symlinked (before a
`unstable` symlink is created), `komodoenv` started failing. Adding
`--no-update` fixes this.