### PR TITLE
Remove agent requirements for xUnitTest

### DIFF
--- a/vars/xUnitTest.groovy
+++ b/vars/xUnitTest.groovy
@@ -6,7 +6,6 @@ def call(Map args = [:]) {
     }
 
     pipeline {
-        agent { label 'master||tr-vresdeploy01.tr.statoil.no||tr-vresdeploy02.tr.statoil.no' }
         options {
             timeout(time: 30, unit: 'MINUTES')
         }


### PR DESCRIPTION
Since we now have more worker-nodes we can afford to run xunittest on more nodes