### PR TITLE
Add ci_install_conan to Jenkins' ci_helper

### DIFF
--- a/jenkins/ci_helper.sh
+++ b/jenkins/ci_helper.sh
@@ -14,6 +14,14 @@ function ci_install_cmake {
     export LD_LIBRARY_PATH=$root/lib:$root/lib64
 }
 
+function ci_install_conan {
+    pip install conan
+
+    # Conan v1 bundles its own certs due to legacy reasons, so we point it
+    # to the system's certs instead.
+    export CONAN_CACERT_PATH=/etc/pki/tls/cert.pem
+}
+
 copy_test_files () {
     if [ -d "$CI_SOURCE_ROOT/tests" ]; then
         cp -r $CI_SOURCE_ROOT/tests $CI_TEST_ROOT/tests


### PR DESCRIPTION
Conan is a C++ package manager which I intend to use in libecl and libres. It's kind of janky but it works better than other attempts at the same thing. One quirk is this certificate business, which this helper should handle for you.