### PR TITLE
Remove depth limit when cloning repositories

### DIFF
--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -26,7 +26,6 @@ def grab(path, filename = None, version = None, protocol = None,
     elif protocol in ('git'):
         shell(
             "git clone "
-            "--depth 50 "
             "-b {version} "
             "-q --recursive "
             "-- {path} {filename}"


### PR DESCRIPTION
Fixes a bug where the version of the package was wrong,
since the latest tag was not included in the git history.