### PR TITLE
Set mpl backend to headless agg

### DIFF
--- a/vars/testKomodo.groovy
+++ b/vars/testKomodo.groovy
@@ -136,6 +136,7 @@ def call(Map args = [:]) {
                         git log -n 1
                         source ${env.CI_SOURCE_ROOT}/${params.TEST_SCRIPT}
                         git log -n 1
+                        export MPLBACKEND=agg
                         run_tests
                     """
                     }


### PR DESCRIPTION
Newer version of matplotlib is failing at `import matplotlib.pyplot` when running in a headless environment as it tries to set backend to qtagg which requires an interactive environment. The backend can be set by using the env variable MPLBACKEND, and should be headless for all tests running on jenkins. Thus setting it in the testKomodo script. 