### PR TITLE
Update pysnyk to equinor version enabling latest importlib_metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "packaging",
         "PyGithub >= 1.55",
         "jinja2",
-        "pysnyk; python_version >= '3.7'",
+        "pysnyk @ git+https://github.com/equinor/pysnyk ; python_version >= '3.7'",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Importlib_metadata needs to be recent due to conflicts with upstream pysnyk libraly. Therefore creating our own at the moment until the issue https://github.com/snyk-labs/pysnyk/issues is resolved 