### PR TITLE
Drop Python 3.6 support for the tool

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.8]
 
     runs-on: ubuntu-latest
 
@@ -55,7 +55,13 @@ jobs:
         python -c "import numpy;print(numpy.__file__)"
         ci/travis/test_import_lib.py
 
-    - name: Test that everything makes sense
+    - name: Test enable script
       run: |
         source /tmp/pfx/travis/enable
         [[ "$(which python)" == "/tmp/pfx/travis/root/bin/python" ]]
+
+    - name: Test Python version
+      run: |
+        source /tmp/pfx/travis/enable
+        pyver=$(python -c 'from sys import version_info as v;print(f"{v[0]}.{v[1]}")')
+        [[ "${pyver}" == "${{ matrix.python-version }}" ]]

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,29 +24,22 @@ function cleanup {
 }
 
 function install_komodo {
-    # Install the environment that the kmd executable will run in. We also
-    # install the virtualenv package because the user might specify to target
-    # Python 2.7, where the 'venv' module doesn't exist.
+    # Install the environment that the kmd executable will run in.
 
-    python3_bin=/usr/bin/python3
+    python3_bin=/usr/bin/python3.8
 
-    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-        # Travis provides Python via a virtualenv, lets respect that
-        python3_bin=`which python`
+    if [[ ! -f "${python3_bin}" ]]; then
+        # Lets assume we're on a RHEL 7 machine
+        python3_bin=/opt/rh/rh-python38/root/usr/bin/python3.8
     fi
     if [[ ! -f "${python3_bin}" ]]; then
-        # Lets assume we're on an Equinor machine
-        python3_bin=/prog/sdpsoft/python3.6.4/bin/python3
-    fi
-    if [[ ! -f "${python3_bin}" ]]; then
-        echo "Couldn't find a Python 3 binary"
+        echo "Couldn't find a Python 3.8 binary"
         exit 1
     fi
 
     echo "Installing Komodo"
     $python3_bin -m venv boot/kmd-env
-    boot/kmd-env/bin/python -m pip install --upgrade pip pytest virtualenv
-    boot/kmd-env/bin/python -m pip install .
+    boot/kmd-env/bin/python -m pip install virtualenv pytest .
 }
 
 function install_devtoolset {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "packaging",
         "PyGithub >= 1.55",
         "jinja2",
-        "pysnyk @ git+https://github.com/equinor/pysnyk ; python_version >= '3.7'",
+        "pysnyk @ git+https://github.com/equinor/pysnyk",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Komodo (the tool) will require Python 3.8. The Python version in the
output Komodo environment is unaffected by this change.