### PR TITLE
Source python3.8 in symlink suggester

### DIFF
--- a/jenkins/symlink/suggester/Jenkinsfile
+++ b/jenkins/symlink/suggester/Jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
                 withCredentials([usernamePassword(credentialsId: "${env.GITHUB_CREDENTIAL}", usernameVariable: 'GH_USER', passwordVariable: 'GITHUB_TOKEN')]) {
                     sh """
                         source /project/res/SDP_bashrc
+                        source /opt/rh/rh-python38/enable
                         python3 -m venv env
                         source env/bin/activate
                         pip install .


### PR DESCRIPTION
Symlink suggester fails due to pysnyk requires `>=Python3.7` hence sourcing Python3.8 first.