### PR TITLE
Add `python_requires` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "jinja2",
         "pysnyk @ git+https://github.com/equinor/pysnyk",
     ],
+    python_requires="~=3.8",
     entry_points={
         "console_scripts": [
             "kmd = komodo.cli:cli_main",


### PR DESCRIPTION
Tried to install `komodo` locally on Python 3.6, but that failed due to the given dependency version constraints are not available on Python 3.6.

Added `python_requires` in order to communicate minimum Python version (which is 3.8 after #245).

