### PR TITLE
Run all komodo integration tests against bleeding-py38

### DIFF
--- a/vars/komodo.groovy
+++ b/vars/komodo.groovy
@@ -65,9 +65,9 @@ def call(Map args = [:]) {
         agent { label getAgentLabel() }
 
         parameters {
-            string name: 'RH_VERSION', defaultValue: '6',
+            string name: 'RH_VERSION', defaultValue: '7',
                 description: 'Dictates on what Red Hat version the build runs, as well as what version it targets'
-            string name: 'PYTHON_VERSION', defaultValue: '2.7',
+            string name: 'PYTHON_VERSION', defaultValue: '3.8',
                 description: 'The target Python version'
 
             string name: 'MATRIX_FILE_BASE', defaultValue: 'bleeding',

--- a/vars/testKomodo.groovy
+++ b/vars/testKomodo.groovy
@@ -44,7 +44,7 @@ def call(Map args = [:]) {
             string name: 'GIT_HELPER_FORK', defaultValue: 'Equinor'
             string name: 'GIT_HELPER_REF', defaultValue: 'master'
 
-            string name: 'KOMODO_RELEASE', defaultValue: 'bleeding-py36'
+            string name: 'KOMODO_RELEASE', defaultValue: 'bleeding-py38'
             string(name: 'TEST_SCRIPT', defaultValue: "ci/jenkins/testkomodo.sh", description: 'The custom script for running tests against komodo')
         }
 

--- a/vars/xUnitTest.groovy
+++ b/vars/xUnitTest.groovy
@@ -29,7 +29,7 @@ def call(Map args = [:]) {
                         }
                         axis {
                             name 'PY_VERSION'
-                            values '3.6'
+                            values '3.8'
                         }
                     }
                     stages {


### PR DESCRIPTION
Run all komodo integration tests for different repositories against 3.8 instead of 3.6 by default.
