### PR TITLE
Remove Python 3.6 from default build matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are in e.g CI and only want to check style compliance, add `--check`.
 You can show reverse dependencies of a package by running the komodo/reverse_dep_graph.py
 Example of use:
 ```bash
-python komodo/reverse_dep_graph.py releases/2020.08.01-py36.yml repository.yml --pkg libres 
+python komodo/reverse_dep_graph.py releases/2020.08.01-py38.yml repository.yml --pkg libres
 ```
 If --pkg is not specified, the program will prompt for it.
 

--- a/jenkins/matrix-build/Jenkinsfile
+++ b/jenkins/matrix-build/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                     }
                     axis {
                         name 'PY_VERSION'
-                        values '3.6', '3.8'
+                        values '3.8'
                     }
                 }
                 stages {

--- a/komodo/lint.py
+++ b/komodo/lint.py
@@ -48,7 +48,7 @@ def _validate(pkg, ver, repo):
 def lint_release_name(pkgfile):
     relname = os.path.basename(pkgfile)
     found = False
-    for py_suffix in "-py27", "-py36":
+    for py_suffix in "-py27", "-py36", "-py38":
         for rh_suffix in "", "-rhel6", "-rhel7":
             if relname.endswith(py_suffix + rh_suffix + ".yml"):
                 found = True

--- a/komodo/matrix.py
+++ b/komodo/matrix.py
@@ -5,7 +5,7 @@ repeat itself."""
 import itertools
 
 RH_VERSIONS = ["7"]
-PY_VERSIONS = ["3.6", "3.8"]
+PY_VERSIONS = ["3.8"]
 
 
 def get_matrix():

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -9,10 +9,10 @@ def test_format_matrix():
 @pytest.mark.parametrize(
     "test_input,expected",
     [
-        ("1970.12.01-py36-rhel7", "1970.12.01"),
-        ("1970.12.rc0-foo-py36-rhel7", "1970.12.rc0-foo"),
+        ("1970.12.01-py38-rhel7", "1970.12.01"),
+        ("1970.12.rc0-foo-py38-rhel7", "1970.12.rc0-foo"),
         ("1970.12.03", "1970.12.03"),
-        (matrix.format_release("1970.12.04", "rhel7", "py36"), "1970.12.04"),
+        (matrix.format_release("1970.12.04", "rhel7", "py38"), "1970.12.04"),
         ("1970.12.05-rhel8-py27", "1970.12.05-rhel8-py27"),  # outside matrix
     ],
 )

--- a/tests/test_non_deployed.py
+++ b/tests/test_non_deployed.py
@@ -19,13 +19,13 @@ def test_non_deployed_empty(tmpdir):
         os.makedirs(release_folder)
 
         # partially deployed, but this currently means it is deployed
-        os.makedirs(os.path.join(install_root, "2019.12.02-py36-rhel7/root"))
-        os.makedirs(os.path.join(install_root, "2022.02.01-py36-rhel7/root"))
+        os.makedirs(os.path.join(install_root, "2019.12.02-py38-rhel7/root"))
+        os.makedirs(os.path.join(install_root, "2022.02.01-py38-rhel7/root"))
 
         _create_links(
             (
-                ("2019.12.02-py36-rhel7", "2019.12"),
-                ("2022.02.01-py36-rhel7", "2022.02"),
+                ("2019.12.02-py38-rhel7", "2019.12"),
+                ("2022.02.01-py38-rhel7", "2022.02"),
             ),
             root=install_root,
         )
@@ -41,7 +41,7 @@ def test_non_deployed(tmpdir):
         os.makedirs(release_folder)
 
         # Fully deployed
-        os.makedirs(os.path.join(install_root, "2019.11.05-py36-rhel7/root"))
+        os.makedirs(os.path.join(install_root, "2019.11.05-py38-rhel7/root"))
 
         # Create matrix files
         open(os.path.join(release_folder, "2019.11.05.yml"), "a").close()
@@ -59,13 +59,13 @@ def test_links_ignored(tmpdir):
         os.makedirs(release_folder)
 
         # partially deployed, but this currently means it is deployed
-        os.makedirs(os.path.join(install_root, "2019.12.01-py36-rhel7/root"))
-        os.makedirs(os.path.join(install_root, "2022.02.02-py36-rhel7/root"))
+        os.makedirs(os.path.join(install_root, "2019.12.01-py38-rhel7/root"))
+        os.makedirs(os.path.join(install_root, "2022.02.02-py38-rhel7/root"))
 
         _create_links(
             (
-                ("2019.12.01-py36-rhel7", "stable"),
-                ("2022.02.02-py36-rhel7", "testing"),
+                ("2019.12.01-py38-rhel7", "stable"),
+                ("2022.02.02-py38-rhel7", "testing"),
             ),
             root=install_root,
         )

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -60,6 +60,7 @@ def test_unused_versions():
     files = [
         os.path.join(_get_test_root(), "data/test_releases/2020.01.a1-py27.yml"),
         os.path.join(_get_test_root(), "data/test_releases/2020.01.a1-py36.yml"),
+        os.path.join(_get_test_root(), "data/test_releases/2020.01.a1-py38.yml"),
     ]
     used_versions = load_all_releases(files)
 

--- a/tests/test_release_transpiler.py
+++ b/tests/test_release_transpiler.py
@@ -41,5 +41,5 @@ def test_transpile(tmpdir):
     with tmpdir.as_cwd():
         transpile_releases(release_file, os.getcwd())
         for rhel_ver in ("rhel7",):
-            for py_ver in ("py36", "py38"):
+            for py_ver in ("py38", ):
                 assert os.path.isfile("{}-{}-{}.yml".format(release_base, py_ver, rhel_ver))


### PR DESCRIPTION
Remove Python 3.6 from default build matrix