### PR TITLE
Change nodes for xUnitTest to run on label 'orchestrating'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: ["3.6", "3.8"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -29,7 +29,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install csh
-      
+
     - name: Setup Komodo
       run: |
         ./bootstrap.sh `which python`

--- a/vars/xUnitTest.groovy
+++ b/vars/xUnitTest.groovy
@@ -4,7 +4,7 @@ def call(Map args = [:]) {
     def time_out = args.time_out ? args.time_out : 60
 
     pipeline {
-        agent { label 'master||scout-ci'}
+        agent { label 'master||orchestrating'}
         options {
             timeout(time: "${time_out}", unit: 'MINUTES')
         }
@@ -21,7 +21,7 @@ def call(Map args = [:]) {
         stages {
             stage('Test Matrix') {
                 matrix {
-                    agent { label 'master||scout-ci' }
+                    agent { label 'master||orchestrating' }
                     axes {
                         axis {
                             name 'RH_VERSION'


### PR DESCRIPTION
To prevent deadlocks with only orchestrating jobs, we reduce the nodes these jobs can run on.