### PR TITLE
Bump github actions/checkout to v3

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: ['3.8']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
v2 gives a deprecation warning