### PR TITLE
Group kmd arguments and provide better cache default

### DIFF
--- a/komodo/build.py
+++ b/komodo/build.py
@@ -326,7 +326,7 @@ def make(
             builddir=builddir,
             makeopts=current.get("makeopts"),
             makefile=current.get("makefile"),
-            dlprefix=dlprefix if dlprefix else ".",
+            dlprefix=dlprefix,
             jobs=jobs,
             cmake=cmk,
             pip=pip,

--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -167,34 +167,60 @@ def _main(args):
 
 
 def cli_main():
-    parser = argparse.ArgumentParser(description="build distribution")
+    """
+    Set up the command-line interface with three groups of arguments:
+      - required positional arguments
+      - required named arguments
+      - optional named arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Welcome to Komodo. "
+        "Automatically, reproducibly, and testably create software "
+        "distributions.",
+        add_help=False,
+    )
+
     parser.add_argument("pkgs", type=YamlFile())
     parser.add_argument("repo", type=YamlFile())
-    parser.add_argument("--prefix", "-p", type=str, required=True)
-    parser.add_argument("--release", "-r", type=str, required=True)
 
-    parser.add_argument("--tmp", "-t", type=str)
-    parser.add_argument("--cache", "-c", type=str)
-    parser.add_argument("--jobs", "-j", type=int, default=1)
+    required_args = parser.add_argument_group("required named arguments")
 
-    parser.add_argument("--download", "-d", action="store_true")
-    parser.add_argument("--build", "-b", action="store_true")
-    parser.add_argument("--install", "-i", action="store_true")
-    parser.add_argument("--dry-run", "-n", action="store_true")
+    required_args.add_argument("--prefix", "-p", type=str, required=True)
+    required_args.add_argument("--release", "-r", type=str, required=True)
+    required_args.add_argument(
+        "--locations-config",
+        type=str,
+        required=True,
+        help="Path to locations.yml, a map of location to a server.",
+    )
 
-    parser.add_argument("--cmake", type=str, default="cmake")
-    parser.add_argument("--pip", type=str, default="pip")
-    parser.add_argument(
+    optional_args = parser.add_argument_group("optional arguments")
+
+    optional_args.add_argument(
+        "--help", "-h", action="help", help="show this help message and exit"
+    )
+    optional_args.add_argument("--tmp", "-t", type=str)
+    optional_args.add_argument("--cache", "-c", type=str, default="pip-cache")
+    optional_args.add_argument("--jobs", "-j", type=int, default=1)
+
+    optional_args.add_argument("--download", "-d", action="store_true")
+    optional_args.add_argument("--build", "-b", action="store_true")
+    optional_args.add_argument("--install", "-i", action="store_true")
+    optional_args.add_argument("--dry-run", "-n", action="store_true")
+
+    optional_args.add_argument("--cmake", type=str, default="cmake")
+    optional_args.add_argument("--pip", type=str, default="pip")
+    optional_args.add_argument(
         "--virtualenv",
         type=str,
         default="virtualenv",
         help="What virtualenv command to use",
     )
-    parser.add_argument("--pyver", type=str, default="3.8")
+    optional_args.add_argument("--pyver", type=str, default="3.8")
 
-    parser.add_argument("--sudo", action="store_true")
-    parser.add_argument("--workspace", type=str, default=None)
-    parser.add_argument(
+    optional_args.add_argument("--sudo", action="store_true")
+    optional_args.add_argument("--workspace", type=str, default=None)
+    optional_args.add_argument(
         "--extra-data-dirs",
         nargs="+",
         type=str,
@@ -202,15 +228,9 @@ def cli_main():
         help="Directories containing extra data files. "
         "Multiple directores can be given, separated with space.",
     )
-    parser.add_argument("--postinst", "-P", type=str)
-    parser.add_argument(
-        "--locations-config",
-        type=str,
-        required=True,
-        help="Path to locations.yml, a map of location to a server.",
-    )
+    optional_args.add_argument("--postinst", "-P", type=str)
 
-    parser.add_argument("--renamer", "-R", default="rename", type=str)
+    optional_args.add_argument("--renamer", "-R", default="rename", type=str)
 
     args = parser.parse_args()
 

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -47,7 +47,7 @@ def grab(path, filename=None, version=None, protocol=None, pip="pip"):
         raise NotImplementedError(f"Unknown protocol {protocol}")
 
 
-def fetch(pkgs, repo, outdir=".", pip="pip"):
+def fetch(pkgs, repo, outdir, pip="pip"):
     missingpkg = [pkg for pkg in pkgs if pkg not in repo]
     missingver = [
         pkg for pkg, ver in pkgs.items() if pkg in repo and ver not in repo[pkg]
@@ -66,7 +66,12 @@ def fetch(pkgs, repo, outdir=".", pip="pip"):
     if missingpkg or missingver:
         return
 
-    if outdir and not os.path.exists(outdir):
+    if not outdir:
+        raise ValueError(
+            "The value of `outdir`, the cache location for pip and other "
+            "tools, cannot be None or the empty string."
+        )
+    elif not os.path.exists(outdir):
         os.mkdir(outdir)
 
     pypi_packages = []


### PR DESCRIPTION
Improves the user interface with new group of 'required named arguments'.
Required overriding the 'optional arguments' group as well to get --help
to continue to make sense.

Also adds a more sensible default value for kmd's --cache (for pip); the
previous default of `.` caused the application to crash.

Not totally sure how this will merge with Håvard's recent PR.