### PR TITLE
add cli tool to query version of package in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ packages
 - `komodo-non-deployed` &mdash; Outputs the name of undeployed matrices given
 an installation root and a release folder
 - `komodo-transpiler` &mdash; Build release files
+- `komodo-show-version` &mdash; Return the version of a specified package in the active release
 
 ### Auto-formatting configuration files
 

--- a/komodo/show_version.py
+++ b/komodo/show_version.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+import argparse
+import configparser
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+import yaml
+
+from komodo.yaml_file_type import ManifestFile
+
+
+def get_release() -> str:
+    """
+    Get the komodo release from the active environment.
+
+    The value of the KOMODO_RELEASE environment variable implicitly tells
+    us the kind of environment we are in. If it looks like an ordinary name,
+    it is probably a komodo environment. However, if it is a path, it is a
+    komodoenv environment.
+
+    We need to know the kind of environment because komodo and komodoenv
+    environments store their manifest files (and root folders) in different
+    places.
+    """
+    try:
+        return os.environ["KOMODO_RELEASE"]
+    except KeyError:
+        message = textwrap.dedent(
+            """
+            No active komodo environment found.
+
+            Either run this command from an active komodo or komodoenv environment,
+            or provide an environment manifest file path with the --path option.\
+            """
+        )
+        sys.exit(message)
+
+
+def read_config(fname: Union[str, Path]) -> dict:
+    """
+    Read an INI file (aka config file) that does not have sections.
+    Sections are part of the INI file format specification and cannot be read
+    by a `configparser.ConfigParser` without them. This function creates a
+    temporary 'MAIN' section and passes back its contents.
+
+    Args:
+        fname: the path to a 'flat' config file, i.e. one with no sections.
+
+    Returns:
+        The configuration.
+    """
+    config = configparser.ConfigParser()
+    with open(fname, "rt", encoding="utf-8") as stream:
+        config.read_string("[MAIN]\n" + stream.read())
+    return dict(config["MAIN"])
+
+
+def get_komodoenv_path(release: str) -> Path:
+    """
+    Use the release name to find the 'real' release path, but from a
+    komodoenv environment. These environments overwrite the environment
+    variable $KOMODO_RELEASE and $PATH, but they store the original path
+    in the komodoenv at 'root/pyvenv.cfg'.
+
+    Args:
+        release: The name of the release, e.g. as stored in the KOMODO_RELEASE
+            environment variable.
+
+    Returns:
+        The path to the release, where the 'root/bin' folder is.
+    """
+    config = read_config(Path(release) / "root" / "pyvenv.cfg")
+    path, *_ = config["home"].split("/root/bin")
+    return Path(path)
+
+
+def get_komodo_path(release: str) -> Path:
+    """
+    Use the release name to find the 'real' release path in an ordinary
+    komodo environment. E.g., the release may be something like
+    '2023.01.02-py38' but the 'real' release (where the release manifest
+    is stored) might be platform-specific, e.g. '2023.01.02-py38-rhel7'.
+    The real path is in the PATH, so we try to get it from there.
+
+    Args:
+        release: The name of the release, e.g. from $KOMODO_RELEASE.
+
+    Returns:
+        The path to the release, where the 'root/bin' folder is.
+    """
+    paths = os.environ["PATH"]
+    pattern = re.compile(rf"(.*?{release}.*?)/root/bin")
+    result = pattern.search(paths)
+    if result is not None:
+        (path,) = result.groups()
+    else:
+        message = f"Could not retrieve the path to the release {release}."
+        raise RuntimeError(message)
+    return Path(path)
+
+
+def get_version(pkg: str, manifest: Optional[Dict] = None) -> str:
+    """
+    Get the release number (or git commit hash) for a package in a
+    komodo release file. If no file is specified, the current release
+    is used. If no environment is active, the path to the release
+    must be specified.
+
+    Args:
+        pkg: The name of the package to get the version for.
+        manifest: Optional. A mapping of packages to dicts of version and
+            maintainer. Typically, this will come from the YAML file created
+            by komodo when it builds a release.
+
+    Returns:
+        The version number or git hash of the version.
+    """
+    path = None
+    if manifest is None:
+        release = get_release()
+        if (Path(release) / "komodoenv.conf").is_file():
+            path = get_komodoenv_path(release)
+        else:
+            path = get_komodo_path(release)
+        release_file = path.parts[-1]
+
+        with open(path / release_file, "rt", encoding="utf-8") as stream:
+            manifest = yaml.safe_load(stream)
+
+    package = manifest.get(pkg)
+
+    if package is None:
+        path_str = f" {path / release_file}" if path is not None else ""
+        message = f"The package {pkg} is not found in the manifest file{path_str}."
+        raise KeyError(message)
+
+    return package.get("version")
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    """
+    Parse the arguments from the command line into an `argparse.Namespace`.
+    Having a separated function makes it easier to test the CLI.
+
+    Args:
+        args: A sequence of arguments, e.g. as collected from the command line.
+
+    Returns:
+        The `argparse.Namespace`, a mapping of arg names to values.
+    """
+    parser = argparse.ArgumentParser(
+        description="Return the version of a specified package in the active "
+        "release or in a given release manifest file."
+    )
+    parser.add_argument("package", help="Package to find the version for.")
+    parser.add_argument(
+        "--manifest-file",
+        type=ManifestFile(),
+        required=False,
+        help="The full path to a release manifest file. This file is "
+        "produced by komodo when it builds an environment. If omitted, "
+        "komodo-show-version will try to find the file for the active "
+        "environment.",
+    )
+    return parser.parse_args(args)
+
+
+def main() -> str:
+    """
+    Run the CLI and return the result from get_version().
+    """
+    args = parse_args(sys.argv[1:])
+    return get_version(args.package, manifest=args.manifest_file)
+
+
+if __name__ == "__main__":
+    print(main())

--- a/komodo/yaml_file_type.py
+++ b/komodo/yaml_file_type.py
@@ -31,3 +31,23 @@ class ReleaseDir:
         for yml_file in Path(value).glob("*.yml"):
             result.update(ReleaseFile()(yml_file))
         return result
+
+
+class ManifestFile(YamlFile):
+    """
+    Return the data from 'manifest' YAML, but validate it first.
+    """
+
+    def __call__(self, value: str) -> Dict[str, Dict[str, str]]:
+        yaml = super().__call__(value)
+        message = (
+            "The file you provided does not appear to be a manifest file "
+            "produced by komodo. It may be a release file. Manifest files "
+            "have a format like the following:\n\n"
+            "python:\n  maintainer: foo@example.com\n  version: 3-builtin\n"
+            "treelib:\n  maintainer: foo@example.com\n  version: 1.6.1\n"
+        )
+        for _, metadata in yaml.items():
+            assert isinstance(metadata, dict), message
+            assert isinstance(metadata["version"], str), message
+        return yaml

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             "komodo-reverse-deps = komodo.reverse_dep_graph:main",
             "komodo-insert-proposals = komodo.insert_proposals:main",
             "komodo-check-pypi = komodo.check_up_to_date_pypi:main",
+            "komodo-show-version = komodo.show_version:main",
         ]
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+import os
+from unittest.mock import mock_open, patch
+
+import pytest
+
+
+@pytest.fixture()
+def mock_komodo_env_vars():
+    """
+    Provide the environment vars from a komodo environment.
+    """
+    env = {
+        "PATH": "/foo/bar/komodo-release-0.0.1/root/bin",
+        "KOMODO_RELEASE": "komodo-release-0.0.1",
+    }
+    with patch.dict(os.environ, env):
+        yield
+
+
+@pytest.fixture()
+def mock_bad_komodo_env_vars():
+    """
+    Provide environment vars from a komodo environment, but the variables are
+    not consistent with each other.
+    """
+    env = {
+        "PATH": "/foo/bar/komodo-release-99.99.99/root/bin",
+        "KOMODO_RELEASE": "komodo-release-0.0.1",
+    }
+    with patch.dict(os.environ, env):
+        yield
+
+
+@pytest.fixture()
+def mock_komodoenv_env_vars():
+    """
+    Provide the environment vars for a *komodoenv* environment. These are
+    different from komodo environments in that the name will not necessarily
+    match an original komodo release, and the given path does not contain a
+    komodo manifest file.
+    """
+    env = {
+        "PATH": "/quux/komodo-release/root/bin",
+        "KOMODO_RELEASE": "/quux/komodo-release",
+    }
+    with patch.dict(os.environ, env):
+        yield
+
+
+@pytest.fixture()
+def mock_config_file():
+    """
+    Mock a sectionless INI file, which is the format komodoenv writes into
+    the pyvenv.cfg file that points to the real komodo root.
+    """
+    read_data = (
+        "home = /foo/bar/komodo-release-0.0.1/root/bin\n"
+        "include-system-site-packages = false\n"
+        "version = 3.8.14\n"
+    )
+    m = mock_open(read_data=read_data)
+    with patch("builtins.open", m):
+        yield m
+
+
+@pytest.fixture()
+def mock_version_manifest():
+    """
+    Mock the manifest file that komodo creates when building an environment.
+    """
+    read_data = (
+        "foo:\n  maintainer: jdoe\n  version: 1.2.3\n"
+        "bar:\n  maintainer: jbloggs\n  version: 99.99.99"
+    )
+    m = mock_open(read_data=read_data)
+    with patch("builtins.open", m):
+        yield m
+
+
+@pytest.fixture()
+def mock_release_file():
+    """
+    Mock a release specification file that komodo _consumes_ when building
+    an environment. Passing it to komodo-show-version raises an error.
+    """
+    read_data = "foo: 1.2.3\nbar: 99.99.99"
+    m = mock_open(read_data=read_data)
+    with patch("builtins.open", m):
+        yield m

--- a/tests/test_show_version.py
+++ b/tests/test_show_version.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+import pytest
+
+from komodo.show_version import (
+    get_komodo_path,
+    get_komodoenv_path,
+    get_release,
+    get_version,
+    parse_args,
+    read_config,
+)
+
+
+def test_read_config_file(mock_config_file):
+    """Test the function that reads sectionless INI files."""
+    config = read_config("foo.cfg")
+    mock_config_file.assert_called_once_with("foo.cfg", "rt", encoding="utf-8")
+    assert config["home"] == "/foo/bar/komodo-release-0.0.1/root/bin"
+
+
+def test_get_release(mock_komodo_env_vars):
+    """Check the environment variable is picked up."""
+    assert get_release() == "komodo-release-0.0.1"
+
+
+def test_get_release_fails_without_env_var():
+    """
+    Check that the script exists gracefully if not run in a komodo environment.
+    """
+    with pytest.raises(SystemExit) as exception_info:
+        _ = get_release()
+    assert "No active komodo environment found." in str(exception_info.value)
+
+
+def test_get_komodo_path(mock_komodo_env_vars):
+    """
+    This is the standard scenario when using an ordinary komodo (not komodoenv)
+    environment. This test checks that the correct path is detected from the
+    mocked environment.
+    """
+    release = get_release()
+    path = Path("/foo/bar/komodo-release-0.0.1")
+    assert get_komodo_path(release) == path
+
+
+def test_get_komodoenv_path(mock_komodoenv_env_vars, mock_config_file):
+    """
+    Komodoenv environments wrap komodo environments and hide the location of
+    the manifest file. Test that the `get_komodoenv_path()` function recovers
+    the actual manifest file path from the `pyvenv.cfg` file.
+    """
+    release = get_release()
+    path = Path("/foo/bar/komodo-release-0.0.1")
+    assert get_komodoenv_path(release) == path
+    fname = Path("/quux/komodo-release/root/pyvenv.cfg")
+    mock_config_file.assert_called_once_with(fname, "rt", encoding="utf-8")
+
+
+def test_get_version(mock_komodo_env_vars, mock_version_manifest):
+    """
+    This test should pick up the $KOMODO_RELEASE then correctly
+    read the mocked release 'manifest' file.
+    """
+    fname = Path("/foo/bar/komodo-release-0.0.1/komodo-release-0.0.1")
+    assert get_version("foo") == "1.2.3"
+    mock_version_manifest.assert_called_once_with(fname, "rt", encoding="utf-8")
+
+
+def test_get_version_with_filepath(mock_version_manifest):
+    """
+    Passing in manifest file explicitly. Ignores the environment and handles
+    the file directly.
+
+    Note that the file loading _and validation_ is handled by
+    komodo.yaml_file_type.ManifestFile, hence the different args for `open()`.
+    """
+    fname = "/foo/bar/komodo-release-0.0.1-py38/komodo-release-0.0.1-py38"
+    args = parse_args(["foo", "--manifest-file", fname])
+    assert get_version(args.package, manifest=args.manifest_file) == "1.2.3"
+
+    # Goes through argparse.FileType via komodo.yaml_file_type.ManifestFile.
+    mock_version_manifest.assert_called_once_with(fname, "r", -1, None, None)
+
+
+def test_get_version_fails_with_release_file(mock_release_file):
+    """
+    Passing in manifest file explicitly, but the user provides a release file,
+    not a 'manifest' file. (They _should_ match, but release files are written
+    by users and given to kmd to contruct an environment, whereas manifest files
+    are produced by kmd during environment consutruction.)
+    """
+    fname = "/foo/bar/releases/komodo-release-0.0.1.yml"
+    with pytest.raises(AssertionError) as exception_info:
+        _ = parse_args(["foo", "--manifest-file", fname])
+    assert "does not appear to be a manifest file" in str(exception_info.value)
+
+    # Goes through argparse.FileType via komodo.yaml_file_type.ManifestFile.
+    mock_release_file.assert_called_once_with(fname, "r", -1, None, None)
+
+
+def test_package_not_found_error(mock_komodo_env_vars, mock_version_manifest):
+    """
+    Detecting the environment automatically, but the requested package is not
+    present in the manifest file.
+    """
+    args = parse_args(["quux"])
+    with pytest.raises(KeyError) as exception_info:
+        _ = get_version(args.package, manifest=args.manifest_file)
+    message = (
+        "The package quux is not found in the manifest file "
+        "/foo/bar/komodo-release-0.0.1/komodo-release-0.0.1."
+    )
+    assert message in str(exception_info.value)
+
+
+def test_package_not_found_error_using_manifest(mock_version_manifest):
+    """
+    Passing in a manifest file explicitly, but this time the requested package
+    is not present in that file. In this case, get_vesion() doesn't know and
+    can't show the path that was passed in, but the user knows it anyway.
+    """
+    fname = "/foo/bar/komodo-release-0.0.1/komodo-release-0.0.1"
+    args = parse_args(["quux", "--manifest-file", fname])
+    with pytest.raises(KeyError) as exception_info:
+        _ = get_version(args.package, manifest=args.manifest_file)
+    message = "The package quux is not found in the manifest file"
+    assert message in str(exception_info.value)
+
+
+def test_get_komodo_path_fails(mock_bad_komodo_env_vars):
+    """
+    If the environment has inconsistent information, or the release name
+    does not match the path, then get_komodo_path cannot discover the path
+    to the 'manifest' file and an exception is raised.
+
+    For example, this test mocks an environment where KOMODO_RELEASE
+    does not match anything in the PATH.
+    """
+    release = get_release()
+    assert release == "komodo-release-0.0.1"
+    with pytest.raises(RuntimeError) as exception_info:
+        _ = get_komodo_path(release)
+    message = "Could not retrieve the path to the release"
+    assert message in str(exception_info.value)


### PR DESCRIPTION
The commit contains a new CLI tool, komodo-show-version (named after pip show, which shows more than just version). It detects the active environment and looks up the version (or git commit hash for non-pip packages) from the 'manifest', a text file komodo creates at build time. Works for komodo and komodoenv environments.

The commit also contains tests.

fixes #278