### PR TITLE
Add support for obtaining github tokens from env

### DIFF
--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -5,6 +5,8 @@ import argparse
 import os
 import sys
 
+import jinja2
+
 from komodo.package_version import (
     LATEST_PACKAGE_ALIAS,
     get_git_revision_hash,
@@ -86,7 +88,14 @@ def fetch(pkgs, repo, outdir, pip="pip") -> dict:
                     "pypi_package_name is only valid when building with pip"
                 )
 
-            url = current.get("source")
+            if "source" in current:
+                templater = jinja2.Environment(loader=jinja2.BaseLoader).from_string(
+                    current.get("source")
+                )
+                url = templater.render(os.environ)
+            else:
+                url = None
+
             protocol = current.get("fetch")
             pkg_alias = current.get("pypi_package_name", pkg)
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -4,26 +4,34 @@ from komodo import lint
 
 REPO = {
     "python": {
-        "v2.7.14": {
-            "maintainer": "jokva@statoil.com",
+        "v3.14": {
+            "maintainer": "ertomatic@equinor.com",
             "make": "sh",
             "makefile": "configure",
             "source": "git://github.com/python/cpython.git",
         }
     },
     "requests": {
-        "2.18.4": {
+        "8.18.4": {
             "depends": ["python"],
-            "maintainer": "jokva@statoil.com",
+            "maintainer": "maintainer@equinor.com",
             "make": "pip",
             "source": "pypi",
+        }
+    },
+    "secrettool": {
+        "10.0": {
+            "source": "https://{{ACCESS_TOKEN}}@github.com/equinor/secrettool.git",
+            "fetch": "git",
+            "make": "pip",
+            "maintainer": "Prop Rietary",
         }
     },
 }
 
 RELEASE = {
-    "python": "v2.7.14",
-    "requests": "2.18.4",
+    "python": "v3.14",
+    "requests": "8.18.4",
 }
 
 
@@ -36,16 +44,9 @@ def test_lint():
 @pytest.mark.parametrize(
     "valid",
     (
-        "bleeding-py27.yml",
         "bleeding-py36.yml",
-        "/home/anyuser/komodo-releases/releases/bleeding-py27.yml",
-        "/home/anyuser/komodo/bleeding-py27.yml",
         "/home/anyuser/komodo/2020.01.03-py36-rhel6.yml",
-        "/home/anyuser/komodo/2020.01.03-py27.yml",
-        "myrelease-py27.yml",
         "myrelease-py36.yml",
-        "myrelease-py27-rhel6.yml",
-        "myrelease-py27-rhel7.yml",
         "myrelease-py36-rhel6.yml",
         "myrelease-py36-rhel7.yml",
     ),
@@ -62,7 +63,7 @@ def test_release_name_valid(valid):
         "2020.01.01",
         "2020.01.00.yml",
         "/home/anyuser/komodo-releases/releases/2020.01.00.yml",
-        "bleeding-py27",
+        "bleeding-py36",
         "bleeding-rhel6.yml",
     ),
 )


### PR DESCRIPTION
Any jinja2 template found in the source part for packages in repository.yml will be expanded for environment variables.