### PR TITLE
Avoid whitespace in json output

### DIFF
--- a/komodo/deployed.py
+++ b/komodo/deployed.py
@@ -40,7 +40,7 @@ def fetch_non_deployed(
 
 def output_formatter(release_list: List[str], do_json: bool = False) -> str:
     if do_json:
-        return json.dumps(release_list)
+        return json.dumps(release_list, separators=(",", ":"))
     return "\n".join(release_list)
 
 

--- a/tests/test_non_deployed.py
+++ b/tests/test_non_deployed.py
@@ -85,7 +85,7 @@ def test_links_ignored(tmpdir):
         (["a"], False, "a"),
         (["a"], True, '["a"]'),
         (["a", "b"], False, "a\nb"),
-        (["a", "b"], True, '["a", "b"]'),
+        (["a", "b"], True, '["a","b"]'),
     ],
 )
 def test_output_formatter(release_list, do_json, expected):


### PR DESCRIPTION
This makes it possible to skip an extra jq step in Github actions