### PR TITLE
add help strings for all CLIs

### DIFF
--- a/komodo/check_up_to_date_pypi.py
+++ b/komodo/check_up_to_date_pypi.py
@@ -128,27 +128,30 @@ def insert_upgrade_proposals(upgrade_proposals, repository, releases):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Checks if pypi packages are up to date"
+        description="Checks if pypi packages are up to date.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "release_file",
         type=lambda arg: arg
         if pathlib.Path(arg).is_file()
         else parser.error(f"{arg} is not a file"),
-        help="Release file you would like to check dependencies on.",
+        help="Komodo release file you would like to check dependencies on, "
+        "in YAML format.",
     )
     parser.add_argument(
         "repository_file",
         type=lambda arg: arg
         if pathlib.Path(arg).is_file()
         else parser.error(f"{arg} is not a file"),
-        help="Repository file where the source of the packages is found",
+        help="Komodo repository file where the source of the packages is found, "
+        "in YAML format.",
     )
     parser.add_argument(
         "--propose-upgrade",
         default=False,
         help="If given, will change the repository and release file "
-        "using the argument as name of the release file",
+        "using the argument as name of the release file.",
     )
     parser.add_argument(
         "--python-version",

--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -190,57 +190,152 @@ def cli_main():
         "Automatically, reproducibly, and testably create software "
         "distributions.",
         add_help=False,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
-    parser.add_argument("pkgs", type=YamlFile())
-    parser.add_argument("repo", type=YamlFile())
+    parser.add_argument(
+        "pkgs",
+        type=YamlFile(),
+        help="A Komodo release file mapping package name to version, "
+        "in YAML format.",
+    )
+    parser.add_argument(
+        "repo",
+        type=YamlFile(),
+        help="A Komodo repository file, in YAML format.",
+    )
 
     required_args = parser.add_argument_group("required named arguments")
 
-    required_args.add_argument("--prefix", "-p", type=str, required=True)
-    required_args.add_argument("--release", "-r", type=str, required=True)
+    required_args.add_argument(
+        "--prefix",
+        "-p",
+        type=str,
+        required=True,
+        help="The path of the directory in which you would like to place the "
+        "built environment.",
+    )
+    required_args.add_argument(
+        "--release",
+        "-r",
+        type=str,
+        required=True,
+        help="The name of the release, will be used as the name of the directory "
+        "containing the enable script and environment `root` directory.",
+    )
     required_args.add_argument(
         "--locations-config",
         type=str,
         required=True,
-        help="Path to locations.yml, a map of location to a server.",
+        help="Path to locations file, mapping locations to servers, in YAML format.",
     )
 
     optional_args = parser.add_argument_group("optional arguments")
 
     optional_args.add_argument(
-        "--help", "-h", action="help", help="show this help message and exit"
+        "--help",
+        "-h",
+        action="help",
+        help="Show this help message and exit.",
     )
-    optional_args.add_argument("--tmp", "-t", type=str)
-    optional_args.add_argument("--cache", "-c", type=str, default="pip-cache")
-    optional_args.add_argument("--jobs", "-j", type=int, default=1)
-
-    optional_args.add_argument("--download", "-d", action="store_true")
-    optional_args.add_argument("--build", "-b", action="store_true")
-    optional_args.add_argument("--install", "-i", action="store_true")
-    optional_args.add_argument("--dry-run", "-n", action="store_true")
-
-    optional_args.add_argument("--cmake", type=str, default="cmake")
-    optional_args.add_argument("--pip", type=str, default="pip")
+    optional_args.add_argument(
+        "--tmp",
+        "-t",
+        type=str,
+        help="The directory to use for builds by cmake. None means "
+        "current working directory.",
+    )
+    optional_args.add_argument(
+        "--cache",
+        "-c",
+        type=str,
+        default="pip-cache",
+        help="The temporary directory used for downloads, e.g. by pip.",
+    )
+    optional_args.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=1,
+        help="The number of parallel jobs to use for builds by cmake.",
+    )
+    optional_args.add_argument(
+        "--download",
+        "-d",
+        action="store_true",
+        help="Flag to choose whether to download the packages.",
+    )
+    optional_args.add_argument(
+        "--build",
+        "-b",
+        action="store_true",
+        help="Flag to choose whether to build the packages.",
+    )
+    optional_args.add_argument(
+        "--install",
+        "-i",
+        action="store_true",
+        help="Flag to choose whether to create enable scripts and manifest file.",
+    )
+    optional_args.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Flag to choose whether stop before installing the environment. "
+        "to the `prefix` location.",
+    )
+    optional_args.add_argument(
+        "--cmake",
+        type=str,
+        default="cmake",
+        help="The command to use for cmake builds.",
+    )
+    optional_args.add_argument(
+        "--pip",
+        type=str,
+        default="pip",
+        help="The command to use for pip builds.",
+    )
     optional_args.add_argument(
         "--virtualenv",
         type=str,
         default="virtualenv",
-        help="What virtualenv command to use",
+        help="The command to use for virtual environment construction.",
     )
-    optional_args.add_argument("--pyver", type=str, default="3.8")
-
-    optional_args.add_argument("--sudo", action="store_true")
-    optional_args.add_argument("--workspace", type=str, default=None)
+    optional_args.add_argument(
+        "--pyver",
+        type=str,
+        default="3.8",
+        help="This argument is not used.",
+    )
+    optional_args.add_argument(
+        "--sudo",
+        action="store_true",
+        help="Flag to choose whether to use `sudo` for shell commands when "
+        "installing the environment.",
+    )
+    optional_args.add_argument(
+        "--workspace",
+        type=str,
+        default=None,
+        help="Directory to set as working directory during execution. "
+        "None means current working directory.",
+    )
     optional_args.add_argument(
         "--extra-data-dirs",
         nargs="+",
         type=str,
         default=None,
-        help="Directories containing extra data files. "
+        help="Directories containing extra data files for `sh` builds. "
         "Multiple directores can be given, separated with space.",
     )
-    optional_args.add_argument("--postinst", "-P", type=str)
+    optional_args.add_argument(
+        "--postinst",
+        "-P",
+        type=str,
+        help="Path to a script which will run on the release path "
+        "(prefix/release) after installation.",
+    )
 
     args = parser.parse_args()
 

--- a/komodo/extract_dep_graph.py
+++ b/komodo/extract_dep_graph.py
@@ -56,7 +56,8 @@ def main():
         description=(
             "Extracts dependencies from a given set of packages where "
             "versions will be resolved from a complete release file. "
-        )
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "pkgs",

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -152,10 +152,33 @@ def fetch(pkgs, repo, outdir, pip="pip") -> dict:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="fetch packages")
-    parser.add_argument("pkgfile", type=YamlFile())
-    parser.add_argument("repofile", type=YamlFile())
-    parser.add_argument("--output", "-o", type=str)
-    parser.add_argument("--pip", type=str, default="pip")
+    parser = argparse.ArgumentParser(
+        description="fetch packages",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "pkgfile",
+        type=YamlFile(),
+        help="A Komodo release file mapping package name to version, "
+        "in YAML format.",
+    )
+    parser.add_argument(
+        "repofile",
+        type=YamlFile(),
+        help="A Komodo repository file, in YAML format.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        required=True,
+        help="The cache location for pip and other tools; will be created.",
+    )
+    parser.add_argument(
+        "--pip",
+        type=str,
+        default="pip",
+        help="The command to use for downloading.",
+    )
     args = parser.parse_args()
     fetch(args.pkgfile, args.repofile, outdir=args.output, pip=args.pip)

--- a/komodo/insert_proposals.py
+++ b/komodo/insert_proposals.py
@@ -183,7 +183,8 @@ Source code for this script can be found [here](https://github.com/equinor/komod
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Copy proposals into release and create PR."
+        description="Copy proposals into release and create PR.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "base",

--- a/komodo/lint.py
+++ b/komodo/lint.py
@@ -149,12 +149,24 @@ def lint(pkgfile, repofile):
 
 
 def get_args():
-    parser = argparse.ArgumentParser(description="lint komodo setup")
-    parser.add_argument("pkgfile", type=str)
-    parser.add_argument("repofile", type=str)
+    parser = argparse.ArgumentParser(
+        description="Lint komodo setup.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "pkgfile",
+        type=str,
+        help="A Komodo release file mapping package name to version, "
+        "in YAML format.",
+    )
+    parser.add_argument(
+        "repofile",
+        type=str,
+        help="A Komodo repository file, in YAML format.",
+    )
     parser.add_argument(
         "--verbose",
-        help="Massive amount of outputs",
+        help="Massive amount of outputs.",
         action="store_const",
         dest="loglevel",
         const=logging.INFO,

--- a/komodo/lint_maturity.py
+++ b/komodo/lint_maturity.py
@@ -213,7 +213,10 @@ def define_tag_exceptions(tag_exception_arg):
 
 def get_parser():
 
-    parser = argparse.ArgumentParser(description=("Lint the maturity of packages."))
+    parser = argparse.ArgumentParser(
+        description="Lint the maturity of packages.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "--tag_exceptions",
         nargs="+",
@@ -227,7 +230,7 @@ def get_parser():
         type=lambda arg: arg
         if os.path.isfile(arg)
         else parser.error(f"{arg} is not a valid file"),
-        help="Release file",
+        help="Komodo release file in YAML format.",
     )
     group.add_argument(
         "--release_folder",

--- a/komodo/lint_package_status.py
+++ b/komodo/lint_package_status.py
@@ -48,7 +48,10 @@ def run(package_status, repository):
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(description=("Lint the package status file."))
+    parser = argparse.ArgumentParser(
+        description="Lint the package status file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "package_status",
         type=YamlFile(),
@@ -57,7 +60,8 @@ def get_parser():
     parser.add_argument(
         "repository",
         type=YamlFile(),
-        help="Repository file with all packages listed with dependencies.",
+        help="Komodo repository file with all packages listed with dependencies, "
+        "in YAML format.",
     )
     return parser
 

--- a/komodo/maintainer.py
+++ b/komodo/maintainer.py
@@ -16,9 +16,21 @@ def maintainers(pkgfile, repofile):
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="print maintainers")
-    parser.add_argument("pkgfile", type=str)
-    parser.add_argument("repofile", type=str)
+    parser = argparse.ArgumentParser(
+        description="Print maintainers.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "pkgfile",
+        type=str,
+        help="A Komodo release file mapping package name to version, "
+        "in YAML format.",
+    )
+    parser.add_argument(
+        "repofile",
+        type=str,
+        help="A Komodo repository file, in YAML format.",
+    )
     args = parser.parse_args()
     maints = maintainers(args.pkgfile, args.repofile)
     for pkg, ver, maintainer in maints:

--- a/komodo/post_messages.py
+++ b/komodo/post_messages.py
@@ -1,8 +1,8 @@
+import argparse
 import fnmatch
 import hashlib
 import os
 import shutil
-from argparse import ArgumentParser
 
 import yaml as yml
 
@@ -42,7 +42,10 @@ def copy_files(file_list, dst_path, src_path):
 
 
 def get_parser():
-    parser = ArgumentParser(description="Post messages to a release.")
+    parser = argparse.ArgumentParser(
+        description="Post messages to a release.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     parser.add_argument(
         "--releases",

--- a/komodo/release_cleanup.py
+++ b/komodo/release_cleanup.py
@@ -1,6 +1,6 @@
+import argparse
 import os
 import sys
-from argparse import ArgumentError, ArgumentParser, ArgumentTypeError
 
 from komodo.prettier import load_yaml, prettier, prettified_yaml, write_to_file
 
@@ -72,7 +72,7 @@ def _valid_path_or_files(path):
     elif os.path.isfile(full_path) and _is_yml(full_path):
         yml_files.append(full_path)
     else:
-        raise ArgumentTypeError(f"{path} is not a valid yml-file or folder")
+        raise argparse.ArgumentTypeError(f"{path} is not a valid yml-file or folder")
     return yml_files
 
 
@@ -144,7 +144,7 @@ def add_prettier_parser(subparsers):
 def run_cleanup(args, parser):
     if args.check and args.stdout:
         parser.error(
-            ArgumentError(
+            argparse.ArgumentError(
                 message="Only check, stdout can not be used together!",
                 argument=args.check,
             )
@@ -192,7 +192,10 @@ def run_prettier(args, _):
 
 
 def main(args=None):
-    parser = ArgumentParser(description="Tidy up release and repository files.")
+    parser = argparse.ArgumentParser(
+        description="Tidy up release and repository files.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     subparsers = parser.add_subparsers(
         title="Available user entries",

--- a/komodo/release_transpiler.py
+++ b/komodo/release_transpiler.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
+import argparse
 import itertools
 import os
-from argparse import ArgumentParser, RawTextHelpFormatter
 
 from komodo.matrix import format_release, get_matrix
 from komodo.prettier import load_yaml, write_to_file
@@ -68,8 +68,9 @@ def transpile(args):
 
 
 def main():
-    parser = ArgumentParser(
-        description="Build release files.", formatter_class=RawTextHelpFormatter
+    parser = argparse.ArgumentParser(
+        description="Build release files.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     subparsers = parser.add_subparsers(
@@ -84,28 +85,32 @@ def main():
     matrix_parser = subparsers.add_parser(
         "combine",
         description="""
-Combine release files into a matrix file.
-Output format:
-example-package:
-  rhel7:
-    py36 : # package not included in release
-    py38 : 5.11.13
-  rhel8:
-    py36 : # package not included in release
-    py38 : 5.11.13+builtin""",
-        formatter_class=RawTextHelpFormatter,
+Combine release files into a matrix file. Output format:
+
+  example-package:
+    rhel7:
+      py36 : # package not included in release
+      py38 : 5.11.13
+    rhel8:
+      py36 : # package not included in release
+      py38 : 5.11.13+builtin""",
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     matrix_parser.set_defaults(func=combine)
     matrix_parser.add_argument(
-        "--release-base", help="Name of the release to handle", required=True
+        "--release-base",
+        required=True,
+        help="Name of the release to handle (default: None)",
     )
     matrix_parser.add_argument(
-        "--release-folder", help="Folder with existing release file", required=True
+        "--release-folder",
+        required=True,
+        help="Folder with existing release file (default: None)",
     )
     matrix_parser.add_argument(
         "--override-mapping",
-        help="File containing explicit matrix packages",
         required=True,
+        help="File containing explicit matrix packages (default: None)",
     )
 
     transpile_parser = subparsers.add_parser(
@@ -113,10 +118,14 @@ example-package:
     )
     transpile_parser.set_defaults(func=transpile)
     transpile_parser.add_argument(
-        "--matrix-file", help="Yaml file describing the release matrix", required=True
+        "--matrix-file",
+        required=True,
+        help="Yaml file describing the release matrix",
     )
     transpile_parser.add_argument(
-        "--output-folder", help="Folder to output new release files", required=True
+        "--output-folder",
+        required=True,
+        help="Folder to output new release files",
     )
     args = parser.parse_args()
     args.func(args)

--- a/komodo/reverse_dep_graph.py
+++ b/komodo/reverse_dep_graph.py
@@ -89,21 +89,24 @@ def main():
             "display the graph as an image, but in that case "
             "needs dot (from Graphwiz) and display "
             "(from ImageMagick) installed."
-        )
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
         "base_pkgs",
         type=lambda arg: arg
         if os.path.isfile(arg)
         else parser.error(f"{arg} is not a file"),
-        help="Base file where all packages are listed with wanted versions specified.",
+        help="Base Komodo release file where all packages are listed with "
+        "wanted versions specified, in YAML format.",
     )
     parser.add_argument(
         "repo",
         type=lambda arg: arg
         if os.path.isfile(arg)
         else parser.error(f"{arg} is not a file"),
-        help="Repository file with all packages listed with dependencies.",
+        help="Komodo repository file with all packages listed with dependencies, "
+        "in YAML format.",
     )
     parser.add_argument(
         "--pkg",

--- a/komodo/show_version.py
+++ b/komodo/show_version.py
@@ -33,8 +33,9 @@ def get_release() -> str:
             """
             No active komodo environment found.
 
-            Either run this command from an active komodo or komodoenv environment,
-            or provide an environment manifest file path with the --path option.\
+            Either run this command from an active komodo or komodoenv
+            environment, or provide an environment manifest file path with the
+            --manifest-file option.\
             """
         )
         sys.exit(message)
@@ -154,7 +155,8 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(
         description="Return the version of a specified package in the active "
-        "release or in a given release manifest file."
+        "release or in a given release manifest file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("package", help="Package to find the version for.")
     parser.add_argument(

--- a/komodo/snyk_reporting.py
+++ b/komodo/snyk_reporting.py
@@ -41,14 +41,36 @@ def main() -> None:
 
 def parse_args(args: Dict[str, str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Test a release for security and license issues"
+        description="Test a release for security and license issues.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--orgid", type=str, required=True)
-    parser.add_argument("--repo", type=YamlFile(), required=True)
+    parser.add_argument(
+        "--orgid", type=str, required=True, help="The Snyk organization ID."
+    )
+    parser.add_argument(
+        "--repo",
+        type=YamlFile(),
+        required=True,
+        help="A Komodo repository file, in YAML format.",
+    )
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--release", type=ReleaseFile())
-    group.add_argument("--release-folder", type=ReleaseDir())
-    parser.add_argument("--format-github", action="store_true")
+    group.add_argument(
+        "--release",
+        type=ReleaseFile(),
+        help="A Komodo release file mapping package name to version, "
+        "in YAML format.",
+    )
+    group.add_argument(
+        "--release-folder",
+        type=ReleaseDir(),
+        help="A directory containing Komodo release files.",
+    )
+    parser.add_argument(
+        "--format-github",
+        action="store_true",
+        help="Flag to print vulnerabilities in GitHub-friendly format vs "
+        "console format.",
+    )
 
     return parser.parse_args(args)
 


### PR DESCRIPTION
Most of the CLI tools in Komodo had help strings, but the main one, `kmd`, was missing most of them. This commit makes them all more consistent with each other, and fills in some gaps.

resolves #288

[edit: preformatted text omitted by git CLI]