### PR TITLE
Modify branch name when symlink suggester updates azure configs

### DIFF
--- a/komodo/symlink/suggester/cli.py
+++ b/komodo/symlink/suggester/cli.py
@@ -112,6 +112,8 @@ def suggest_symlink_configuration(
         return None
 
     target_branch = f"{args.release}/{args.mode}"
+    if "azure" in args.symlink_conf_path:
+        target_branch += "/azure"
 
     from_sha = repo.get_branch(args.git_ref).commit.sha
 

--- a/tests/test_suggester.py
+++ b/tests/test_suggester.py
@@ -301,6 +301,50 @@ def test_suggest_symlink_configuration():
     )
 
 
+def test_suggest_symlink_configuration_azure():
+    """
+    Testing whether when updating azure symlink file the branch gets a name
+    release/stable/azure
+    """
+    config = """{"links": {
+"2050.02-py58": "2050.02.00-py58",
+"stable-py58": "2050.02-py58"
+}}"""
+    repo = _mock_repo(config)
+
+    args = Namespace(
+        git_ref="master",
+        release="2050.02.01-py58",
+        mode="stable",
+        symlink_conf_path="foo_azure.json",
+        joburl="http://job",
+        jobname="job",
+    )
+    suggest_symlink_configuration(args, repo)
+
+    repo.get_contents.assert_called_once_with("foo_azure.json", ref="master")
+    repo.get_branch.assert_called_once_with("master")
+    repo.create_git_ref.assert_called_once_with(
+        ref="refs/heads/2050.02.01-py58/stable/azure", sha=ANY
+    )
+    repo.update_file.assert_called_once_with(
+        "foo_azure.json",
+        "Update stable symlinks for 2050.02.01-py58",
+        """{
+    "links": {
+        "2050.02-py58": "2050.02.01-py58",
+        "stable-py58": "2050.02-py58"
+    }
+}
+""",
+        ANY,
+        branch="2050.02.01-py58/stable/azure",
+    )
+    repo.create_pull.assert_called_once_with(
+        title=ANY, body=ANY, head="2050.02.01-py58/stable/azure", base="master"
+    )
+
+
 def test_noop_suggestion():
     config = """{"links": {
 "2050.02-py58": "2050.02.00-py58",


### PR DESCRIPTION
Resolves https://github.com/equinor/komodo-releases/issues/3183

Checks if updater acts on `symlink_configuration/symlink_config_azure.json` and appends `/azure` to release name yielding for instance: `release_name/unstable/azure` branch name.

todo: tests