### PR TITLE
Add transpiler to produce pip requirements file

### DIFF
--- a/tests/data/test_repository.yml
+++ b/tests/data/test_repository.yml
@@ -1,40 +1,61 @@
 lib1:
+  1.2.3+builtin:
+    source: pypi
+    make: sh
+  0.1.2+builtin:
+    source: pypi
+    make: sh
   1.2.3:
     source: pypi
+    make: pip
   0.1.2:
     source: pypi
+    make: pip
   0.0.2:
     source: pypi
-    
+    make: pip
+
 lib2:
   2.3.4:
+    make: pip
     depends:
     - lib1
   1.2.3:
+    make: pip
     depends:
     - lib1
   0.0.2:
+    make: pip
     depends:
     - lib1
-    
+
 lib3:
+  3.4.6:
+    make: rsync
+    depends:
+    - lib1
   3.4.5:
+    make: rsync
     depends:
     - lib1
   2.3.4:
+    make: rsync
     depends:
     - lib1
   master:
+    make: rsync
     depends:
     - lib1
-    
+
 lib4: # comment to be preserved
   3.4.5:
+    make: pip
     depends:
     - lib3
     - lib2
 
 lib5: # comment should be gone
   1.2.3:
+    make: pip
     depends:
     - lib4

--- a/tests/test_release_cleanup.py
+++ b/tests/test_release_cleanup.py
@@ -16,27 +16,34 @@ from tests import _get_test_root, _load_yaml
 expected_result = """lib1:
   1.2.3:
     source: pypi
+    make: pip
   0.1.2:
     source: pypi
+    make: pip
 
 lib2:
   2.3.4:
+    make: pip
     depends:
       - lib1
   1.2.3:
+    make: pip
     depends:
       - lib1
 
 lib3:
   3.4.5:
+    make: rsync
     depends:
       - lib1
   2.3.4:
+    make: rsync
     depends:
       - lib1
 
 lib4: # comment to be preserved
   3.4.5:
+    make: pip
     depends:
       - lib3
       - lib2


### PR DESCRIPTION
this adds a transpiler that can create a pip requirements file from a release matrix file (and a repo).

could for instance be used in workflows as input for checking dependency conflicts, checking for upgradable packages, or scanning for vulnerabilities.