### PR TITLE
Change command line option name from cache to work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
             ci/${RELEASE} \
             ci/repository.yml \
             --workspace ${{ runner.temp }}/kmd-ws \
-            --cache ${{ runner.temp }}/kmd-cache \
             --prefix ${{ runner.temp }}/pfx \
             --release ci \
             --locations-config $(realpath ci/locations.yml) \

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -52,7 +52,7 @@ A full software distribution can then be built and deployed to a specified
 path, e.g. `./builds/stable-0.0.1`, with the following command:
 
 ```bash
-kmd stable.yml repository.yml --prefix builds --release stable-0.0.1 --locations-config locations.yml --cache pip-cache
+kmd stable.yml repository.yml --prefix builds --release stable-0.0.1 --locations-config locations.yml
 ```
 
 To use this environment, type `source builds/stable-0.0.1/enable`.

--- a/komodo/fetch.py
+++ b/komodo/fetch.py
@@ -70,8 +70,12 @@ def fetch(pkgs, repo, outdir, pip="pip") -> dict:
 
     if not outdir:
         raise ValueError(
-            "The value of `outdir`, the cache location for pip and other "
-            "tools, cannot be None or the empty string."
+            "The value of `outdir`, the download destination location "
+            "cannot be None or the empty string."
+        )
+    if os.path.exists(outdir) and os.listdir(outdir):
+        raise RuntimeError(
+            f"Downloading to non-empty directory {outdir} is not supported."
         )
     if not os.path.exists(outdir):
         os.mkdir(outdir)
@@ -171,13 +175,14 @@ if __name__ == "__main__":
         "-o",
         type=str,
         required=True,
-        help="The cache location for pip and other tools; will be created.",
+        help="The download destination for pip, cp, rsync and git. "
+        "Must be non-existing or empty.",
     )
     parser.add_argument(
         "--pip",
         type=str,
         default="pip",
-        help="The command to use for downloading.",
+        help="The command to use for downloading pip packages.",
     )
     args = parser.parse_args()
     fetch(args.pkgfile, args.repofile, outdir=args.output, pip=args.pip)

--- a/tests/data/cli/nominal_repository.yml
+++ b/tests/data/cli/nominal_repository.yml
@@ -17,7 +17,7 @@ setuptools:
 
 hackres:
   0.0.5289:
-    source: ../hackres # we assume here hackres is copied into cache/..
+    source: ../hackres # we assume here hackres is copied into _work/..
     fetch: fs-cp
     make: sh
     makefile: test_build_script.sh


### PR DESCRIPTION
The command line option cache hints to komodo supporting some kind of caching, which it does not. The directory named used as a cache is a working directory used while building, and cannot be prepopulated.