### PR TITLE
Update migration warning

### DIFF
--- a/komodo/switch.py
+++ b/komodo/switch.py
@@ -4,11 +4,11 @@ import shutil
 from jinja2 import Template
 
 MIGRATION_WARNING = (
-    "Attention! Your machine is running on a RHEL6 environment "
-    "which is in the process of being phased out.\n"
-    "New versions of komodo will from October 2020 only support RHEL7.\n"
+    "Attention! Your machine is running on an environment "
+    "that is not supported. RHEL6 has been phased out.\n"
+    "From October 2020, komodo versions only support RHEL7.\n"
     "Please migrate as soon as possible. If you have any questions or issues - "
-    "contact us on #ert-users on Slack or Equinor's Yammer!"
+    "contact us on #ert-users on Slack or Equinor's Yammer."
 )
 
 


### PR DESCRIPTION
The current message looks outdate, since reel6 was already phased out.
Probably could have removed it completely, but better to fail more gracefully if the user falls in the exception.

```
cat /lustre1/prog/komodo/2023.03.01-py38/enable
if [[ $(uname -r) == *el7* ]] ; then
    export KOMODO_ROOT=/lustre1/prog/komodo
    KOMODO_RELEASE_REAL=2023.03.01-py38

    source $KOMODO_ROOT/$KOMODO_RELEASE_REAL-rhel7/enable
    export PS1="(${KOMODO_RELEASE_REAL}) ${_PRE_KOMODO_PS1}"
    export KOMODO_RELEASE=$KOMODO_RELEASE_REAL
else
    echo -e "Attention! Your machine is running on a RHEL6 environment which is in the process of being phased out.
New versions of komodo will from October 2020 only support RHEL7.
Please migrate as soon as possible. If you have any questions or issues - contact us on #ert-users on Slack or Equinor's Yammer!"
fi
```