### PR TITLE
Add missing popd

### DIFF
--- a/ci/func_def.sh
+++ b/ci/func_def.sh
@@ -59,6 +59,7 @@ run_tests_default () {
 
     pushd $CI_TEST_ROOT
     start_tests
+    popd
 }
 
 function run_tests {


### PR DESCRIPTION
This is based on code staring and trying to deduce why we have the failure in 
https://github.com/equinor/komodo-releases/actions/runs/5183563004/jobs/9341978584

```
Submitting: ../mock_bsub -o /mnt/scratch/f_scout_ci/actions-runner-05/_temp/pytest_tmp_dir/pytest-of-f_scout_ci/pytest-0/test_run_mocked_lsf_queue_fail0/test_data/poly_out/realization-7/iter-0/poly_7.LSF-stdout -J poly_7 -n 1 /mnt/scratch/f_scout_ci/actions-runner-05/_temp/test-kenv/root/shims/job_dispatch.py /mnt/scratch/f_scout_ci/actions-runner-05/_temp/pytest_tmp_dir/pytest-of-f_scout_ci/pytest-0/test_run_mocked_lsf_queue_fail0/test_data/poly_out/realization-7/iter-0
1151
+ popd
1152
+ [[ ert == \e\r\t ]]
1153
+ bash ci/run_ert_ctests.sh build_and_test
1154
/mnt/scratch/f_scout_ci/actions-runner-05/_temp/test_root /mnt/scratch/f_scout_ci/actions-runner-05/_temp/source_root /mnt/scratch/f_scout_ci/actions-runner-05/_temp /mnt/scratch/f_scout_ci/actions-runner-05/komodo-releases/komodo-releases
1155
bash: ci/run_ert_ctests.sh: No such file or directory
1156
Error: Process completed with exit code 127.
```