### PR TITLE
Make creating symlinks verbose

### DIFF
--- a/komodo/symlink/create_links.py
+++ b/komodo/symlink/create_links.py
@@ -25,9 +25,13 @@ def _create_link(src, dst, link_dict):
         raise ValueError(f"{src} does not exist")
 
     if os.path.exists(dst) and os.path.islink(dst):
-        if os.readlink(dst) == src:
+        existing_link = os.readlink(dst)
+        if existing_link == src:
             return
         os.remove(dst)
+        print(f"Existing symlink {dst} moved from {existing_link} to {src}")
+    else:
+        print(f"Created new symlink {dst} pointing to {src}")
 
     os.symlink(src, dst)
 

--- a/tests/test_link_io_structure.py
+++ b/tests/test_link_io_structure.py
@@ -68,6 +68,36 @@ def test_create_symlinks(tmpdir):
         assert os.path.realpath("unstable") == os.path.realpath("2012.01.rc2")
 
 
+def test_create_symlink_stdout(tmpdir, capsys):
+    links_dict = {
+        "root_folder": tmpdir,
+        "links": {
+            "2023": "2023.07",
+        },
+    }
+    with tmpdir.as_cwd():
+        os.mkdir("2023.07")
+        create_symlinks(links_dict)
+        captured = capsys.readouterr()
+        assert "Created new symlink 2023 pointing to 2023.07\n" == captured.out
+
+
+def test_overwrite_symlink_stdout(tmpdir, capsys):
+    links_dict = {
+        "root_folder": tmpdir,
+        "links": {
+            "2023": "2023.07",
+        },
+    }
+    with tmpdir.as_cwd():
+        os.mkdir("2023.06")
+        os.mkdir("2023.07")
+        os.symlink("2023.06", "2023")
+        create_symlinks(links_dict)
+        captured = capsys.readouterr()
+        assert "Existing symlink 2023 moved from 2023.06 to 2023.07\n" == captured.out
+
+
 def test_integration(tmpdir):
     test_folder = _get_test_root()
     shutil.copy(os.path.join(test_folder, "data/links.json"), tmpdir)


### PR DESCRIPTION
This allows for forwarding of what the symlink creator actually did to status dashboards.

