### PR TITLE
Be explicit about stacklevel

### DIFF
--- a/komodo/lint_maturity.py
+++ b/komodo/lint_maturity.py
@@ -26,7 +26,7 @@ def print_system_exit_message(system_exit_msg):
 
 def print_warning_message(system_warning_msg):
     if system_warning_msg != "":
-        warnings.warn(system_warning_msg, UserWarning)
+        warnings.warn(system_warning_msg, UserWarning, stacklevel=2)
 
 
 def msg_packages_invalid(


### PR DESCRIPTION
This ensure that the context is preserved when we issue warnings using function wrappers.

Solves flake B028, which for some reason does not seem to trigger on Python 3.10, but does so locally on Python 3.8