### PR TITLE
Fix ReleaseDir class to load *yml files

### DIFF
--- a/komodo/yaml_file_types.py
+++ b/komodo/yaml_file_types.py
@@ -135,8 +135,10 @@ class ReleaseDir:
         if not os.path.isdir(value):
             raise NotADirectoryError(value)
         result = {}
-        for yaml_file in Path(value).glob("*.yaml"):
-            result.update(ReleaseFile()(yaml_file))
+        for yaml_file in Path(value).glob("*.yml"):
+            result[yaml_file.name.replace(".yml", "")] = ReleaseFile()(
+                yaml_file
+            ).content
         return result
 
 

--- a/tests/test_yaml_file_types.py
+++ b/tests/test_yaml_file_types.py
@@ -1,10 +1,12 @@
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
 from komodo.yaml_file_types import (
     KomodoException,
     PackageStatusFile,
+    ReleaseDir,
     ReleaseFile,
     RepositoryFile,
     _komodo_error,
@@ -882,3 +884,21 @@ def test_repository_file_lint_maintainer(
 def test_package_status_file_type(package_status_file_content: str, expectation):
     with expectation:
         PackageStatusFile().from_yaml_string(package_status_file_content)
+
+
+def test_release_dir_with_one_release(tmpdir):
+    with tmpdir.as_cwd():
+        Path("releases").mkdir()
+        Path("releases/somerelease.yml").write_text("foo: 0.4.1", encoding="utf-8")
+        assert ReleaseDir()("releases") == {"somerelease": {"foo": "0.4.1"}}
+
+
+def test_release_dir_with_two_releases(tmpdir):
+    with tmpdir.as_cwd():
+        Path("releases").mkdir()
+        Path("releases/somerelease.yml").write_text("foo: 0.4.1", encoding="utf-8")
+        Path("releases/anotherrelease.yml").write_text("bar: 1.4.1", encoding="utf-8")
+        assert ReleaseDir()("releases") == {
+            "somerelease": {"foo": "0.4.1"},
+            "anotherrelease": {"bar": "1.4.1"},
+        }


### PR DESCRIPTION
This fixes two bugs:
* komodo-transpiler writes yaml files with yml-suffix, while this function assumed it was yaml as suffix.
* ReleaseFile()(yaml_file) did not give a generator that  can use, changed to use content and put it in a subdictionary.