### PR TITLE
Allow a rm command to fail

### DIFF
--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -3,6 +3,7 @@ import contextlib
 import datetime
 import os
 import sys
+import uuid
 import warnings
 from pathlib import Path
 from typing import List, Tuple
@@ -152,7 +153,8 @@ def _main(args):
 
     if Path(f"{args.prefix}/{args.release}").exists():
         shell(
-            f"mv {args.prefix}/{args.release} {args.prefix}/{args.release}.delete",
+            f"mv {args.prefix}/{args.release} "
+            f"{args.prefix}/{args.release}.delete-{uuid.uuid4()}",
             sudo=args.sudo,
         )
 
@@ -161,7 +163,11 @@ def _main(args):
         sudo=args.sudo,
     )
     start_time = datetime.datetime.now()
-    shell(f"rm -rf {args.prefix}/{args.release}.delete", sudo=args.sudo)
+    shell(
+        f"rm -rf {args.prefix}/{args.release}.delete-*",
+        sudo=args.sudo,
+        allow_failure=True,
+    )
     timings.append(("Deleting previous release", datetime.datetime.now() - start_time))
     _print_timings(timings[-1])
 

--- a/komodo/shell.py
+++ b/komodo/shell.py
@@ -15,7 +15,7 @@ def pushd(path):
     os.chdir(prev)
 
 
-def shell(cmd, sudo=False):
+def shell(cmd: str, sudo=False, allow_failure=False) -> bytes:
     try:
         cmdlist = cmd.split(" ")
     except AttributeError:
@@ -33,4 +33,6 @@ def shell(cmd, sudo=False):
         return subprocess.check_output(tuple(filter(None, cmdlist)))
     except subprocess.CalledProcessError as e:
         print(e.output, file=sys.stderr)
+        if allow_failure:
+            return e.output
         raise


### PR DESCRIPTION
The rm <build>.delete statement has been observed to be flaky on NFS filesystems, probably due to leftover .nfs* files blocking deletion of the directories.

We fix this by moving the old release to a unique filename, and let the rm command fail (will be logged to stdout). Subsequent builds will do the cleanup.