### PR TITLE
Fix upgrade-proposals linter bug for multiple releases

### DIFF
--- a/komodo/lint_upgrade_proposals.py
+++ b/komodo/lint_upgrade_proposals.py
@@ -7,11 +7,11 @@ def verify_package_versions_exist(
     upgrade_proposals: UpgradeProposalsFile,
     repository: RepositoryFile,
 ) -> None:
-    releases_with_upgrades_counter = 0
+    found_release_with_upgrades = False
     for proposed_package_upgrades in upgrade_proposals.content.values():
         if proposed_package_upgrades is None:
             continue
-        releases_with_upgrades_counter += 1
+        found_release_with_upgrades = True
         errors = []
         for (
             upgrade_proposals_package,
@@ -27,14 +27,13 @@ def verify_package_versions_exist(
                     f" {upgrade_proposals_package_version} in repository",
                 )
             except KomodoException as e:
-                errors.append(e.error)
+                errors.append("ERROR: " + e.error)
         if errors:
             raise SystemExit("\n".join(errors))
-    if releases_with_upgrades_counter == 0:
+    if found_release_with_upgrades:
         print("No upgrades found")
-    if releases_with_upgrades_counter > 1:
-        msg = "Found upgrades for more than one release"
-        raise SystemExit(msg)
+    else:
+        print("Found upgrades")
 
 
 def get_args() -> argparse.ArgumentParser:

--- a/tests/test_lint_upgrade_proposals.py
+++ b/tests/test_lint_upgrade_proposals.py
@@ -95,6 +95,13 @@ VALID_UPGRADE_PROPOSALS = """
 1111-12:
   python: 3.8.6
 """
+
+INVALID_UPGRADE_PROPOSALS_PACKAGE_NOT_IN_REPOSITORY = """
+1111-11:
+1111-12:
+  testlib: 3.8.6
+"""
+
 VALID_EMPTY_UPGRADE_PROPOSALS = """
 1111-11:
 1111-12:
@@ -189,10 +196,7 @@ yaml
         pytest.param(
             VALID_UPGRADE_PROPOSALS_MULTIPLE_RELEASES,
             VALID_REPOSITORY,
-            pytest.raises(
-                SystemExit,
-                match=r"Found upgrades for more than one release",
-            ),
+            does_not_raise(),
             id="upgrades_in_multiple_releases_in_upgrade_proposals",
         ),
         pytest.param(
@@ -243,6 +247,15 @@ yaml
             pytest.raises(
                 SystemExit,
                 match=r"invalid version type",
+            ),
+            id="invalid_upgrade_proposals_float_package_version",
+        ),
+        pytest.param(
+            INVALID_UPGRADE_PROPOSALS_PACKAGE_NOT_IN_REPOSITORY,
+            VALID_REPOSITORY,
+            pytest.raises(
+                SystemExit,
+                match=r"ERROR: Package 'testlib' not found in repository",
             ),
             id="invalid_upgrade_proposals_float_package_version",
         ),


### PR DESCRIPTION
The new upgrade-proposals linter threw an error if there were multiple releases being upgraded at the same time. This is an intended feature, so that is being removed from the linter in this commit.