### PR TITLE
Add guard to avoid overwriting releases

### DIFF
--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -82,6 +82,9 @@ def _main(args):
     if args.download and not args.build:
         sys.exit(0)
 
+    if (Path(args.prefix) / args.release).exists() and "bleeding" not in args.release:
+        raise RuntimeError("Only bleeding builds can be overwritten")
+
     # append root to the temporary build dir, as we want a named root/
     # directory as the distribution root, organised under the distribution name
     tmp_prefix = abs_prefix / args.release / "root"

--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -82,8 +82,14 @@ def _main(args):
     if args.download and not args.build:
         sys.exit(0)
 
-    if (Path(args.prefix) / args.release).exists() and "bleeding" not in args.release:
-        raise RuntimeError("Only bleeding builds can be overwritten")
+    if (
+        not args.overwrite
+        and (Path(args.prefix) / args.release).exists()
+        and "bleeding" not in args.release
+    ):
+        raise RuntimeError(
+            "Only bleeding builds can be overwritten unless --overwrite is supplied"
+        )
 
     # append root to the temporary build dir, as we want a named root/
     # directory as the distribution root, organised under the distribution name
@@ -386,6 +392,14 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         help=(
             "Flag to choose whether stop before installing the environment. "
             "to the `prefix` location."
+        ),
+    )
+    optional_args.add_argument(
+        "--overwrite",
+        action="store_true",
+        help=(
+            "If set, any existing release will be overwritten. "
+            "If `bleeding` is part of the release name, this is impliclity true."
         ),
     )
     optional_args.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -178,6 +178,30 @@ def test_bleeding_overwrite_by_default(tmpdir):
     cli_main()
 
 
+def test_overwrite_if_option_is_set(tmpdir):
+    sys.argv = [
+        "kmd",
+        "--workspace",
+        str(tmpdir),
+        "--overwrite",
+        os.path.join(_get_test_root(), "data/cli/minimal_release.yml"),
+        os.path.join(_get_test_root(), "data/cli/minimal_repository.yml"),
+        "--prefix",
+        "prefix",
+        "--release",
+        "some_release",
+        "--extra-data-dirs",  # Required to find test_python_builtin.sh.
+        os.path.join(_get_test_root(), "data/cli"),
+    ]
+    cli_main()
+    # Remove non-interesting leftovers from first build:
+    shutil.rmtree(tmpdir / "downloads")
+    shutil.rmtree(tmpdir / ".some_release")
+
+    # Assert that we can overwrite the build inside "some_release"
+    cli_main()
+
+
 def test_pyver_is_deprecated():
     """Pyver is not being used anywhere in the code and has been deprecated.
     This test ensures that its use prints a message in stderr.


### PR DESCRIPTION
Only bleeding builds will be overwritten by default.

Solves the komodo part of https://github.com/equinor/komodo-releases/issues/5063