### PR TITLE
Run lint maturity on the transpiled release file

### DIFF
--- a/komodo/lint_maturity.py
+++ b/komodo/lint_maturity.py
@@ -116,8 +116,10 @@ def msg_release_exception(release_basename, release_version):
 
 
 def get_release_version(release_basename, tag_exceptions_release):
-    if release_basename not in tag_exceptions_release:
-        release_version = get_release_type(release_basename)
+    release_cleanname = release_basename.split("-")[0]
+
+    if release_cleanname not in tag_exceptions_release:
+        release_version = get_release_type(release_cleanname)
     else:
         release_version = "exception"
 
@@ -129,7 +131,7 @@ def run(files_to_lint: List[str], tag_exceptions):
     system_warning_msg = ""
 
     for file_to_lint in files_to_lint:
-        release_basename = ".".join(os.path.basename(file_to_lint).split(".")[0:-1])
+        release_basename = os.path.basename(file_to_lint)
         release_version = get_release_version(
             release_basename,
             tag_exceptions["release"],

--- a/tests/test_lint_maturity.py
+++ b/tests/test_lint_maturity.py
@@ -31,10 +31,10 @@ def _create_tmp_test_files(release_sample, file_names_sample):
 @pytest.mark.parametrize(
     ("release_basename", "release_version", "count_tag_invalid"),
     [
-        ("2020.02.01.yml", "stable", 4),
-        ("2020.02.a1.yml", "a", 1),
-        ("2020.02.b1.yml", "b", 2),
-        ("2020.02.rc1.yml", "rc", 3),
+        ("2020.02.01-py38-rhel7.yml", "stable", 4),
+        ("2020.02.a1-py38-rhel7.yml", "a", 1),
+        ("2020.02.b1-py38-rhel7.yml", "b", 2),
+        ("2020.02.rc1-py38-rhel7.yml", "rc", 3),
     ],
 )
 def test_msg_packages_invalid(release_basename, release_version, count_tag_invalid):
@@ -52,20 +52,20 @@ def test_msg_packages_invalid(release_basename, release_version, count_tag_inval
         },
     )
 
-    expected_system_exit = """2020.02.01.yml has 4 packages with invalid maturity tag.
+    expected_system_exit = """2020.02.01-py38-rhel7.yml has 4 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag b packages: [('package_b1', 'v3.1.b1')]
 \tTag rc packages: [('package_rc1', 'v3.1.rc1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.a1.yml has 1 packages with invalid maturity tag.
+2020.02.a1-py38-rhel7.yml has 1 packages with invalid maturity tag.
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.b1.yml has 2 packages with invalid maturity tag.
+2020.02.b1-py38-rhel7.yml has 2 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.rc1.yml has 3 packages with invalid maturity tag.
+2020.02.rc1-py38-rhel7.yml has 3 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag b packages: [('package_b1', 'v3.1.b1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
@@ -77,10 +77,10 @@ def test_msg_packages_invalid(release_basename, release_version, count_tag_inval
 
 def test_msg_packages_exception():
     release_file_names = [
-        "2020.02.01.yml",
-        "2020.02.a1.yml",
-        "2020.02.b1.yml",
-        "2020.02.rc1.yml",
+        "2020.02.01-py38-rhel7.yml",
+        "2020.02.a1-py38-rhel7.yml",
+        "2020.02.b1-py38-rhel7.yml",
+        "2020.02.rc1-py38-rhel7.yml",
         "bleeding.yml",
     ]
 
@@ -192,18 +192,18 @@ package: ['package_ex2']""",
 def test_msg_release_exception():
     expected_release_version = ["stable", "a", "b", "rc", "exception"]
     release_file_names = [
-        "2020.02.01.yml",
-        "2020.02.a1.yml",
-        "2020.02.b1.yml",
-        "2020.02.rc1.yml",
-        "bleeding.yml",
+        "2020.02.01-py38-rhel7.yml",
+        "2020.02.a1-py38-rhel7.yml",
+        "2020.02.b1-py38-rhel7.yml",
+        "2020.02.rc1-py38-rhel7.yml",
+        "bleeding-py38-rhel7.yml",
     ]
 
     for count, release_basename in enumerate(release_file_names):
         release_version = expected_release_version[count]
         expected_warning_msg = ""
 
-        if release_basename == "bleeding.yml":
+        if release_basename == "bleeding-py38-rhel7.yml":
             expected_warning_msg += (
                 release_basename + " not lint because it is in the exception list.\n"
             )
@@ -219,10 +219,10 @@ def test_msg_release_exception():
 @pytest.mark.parametrize(
     ("release_basename", "expected_release_version"),
     [
-        ("2020.02.01", "stable"),
-        ("2020.02.a1", "a"),
-        ("2020.02.b1", "b"),
-        ("2020.02.rc1", "rc"),
+        ("2020.02.01-py38-rhel7.yml", "stable"),
+        ("2020.02.a1-py38-rhel7.yml", "a"),
+        ("2020.02.b1-py38-rhel7.yml", "b"),
+        ("2020.02.rc1-py38-rhel7.yml", "rc"),
         ("bleeding", "exception"),
         ("invalid_tag", "invalid"),
     ],
@@ -246,22 +246,22 @@ package_st1: v0.10.4
 package_iv1: 5.13.1-src
 package_ex2: testing/2020.3/rc1""",
             file_names_sample=[
-                "2020.02.01.yml",
-                "2020.02.a1.yml",
-                "2020.02.b1.yml",
-                "2020.02.rc1.yml",
+                "2020.02.01-py38-rhel7.yml",
+                "2020.02.a1-py38-rhel7.yml",
+                "2020.02.b1-py38-rhel7.yml",
+                "2020.02.rc1-py38-rhel7.yml",
             ],
         )
 
-        expected_warning = """2020.02.01, exception list of packages:
+        expected_warning = """2020.02.01-py38-rhel7.yml, exception list of packages:
 \t[('package_ex2', 'testing/2020.3/rc1')]
-2020.02.a1, exception list of packages:
+2020.02.a1-py38-rhel7.yml, exception list of packages:
 \t[('package_ex2', 'testing/2020.3/rc1')]
-2020.02.b1, exception list of packages:
+2020.02.b1-py38-rhel7.yml, exception list of packages:
 \t[('package_ex2', 'testing/2020.3/rc1')]
-2020.02.rc1, exception list of packages:
+2020.02.rc1-py38-rhel7.yml, exception list of packages:
 \t[('package_ex2', 'testing/2020.3/rc1')]
-bleeding not lint because it is in the exception list.
+bleeding-py38-rhel7.yml not lint because it is in the exception list.
 bleeding, exception list of packages:
 \t[('package_ex2', 'testing/2020.3/rc1')]
 bleeding has 4 packages with invalid maturity tag.
@@ -271,20 +271,20 @@ bleeding has 4 packages with invalid maturity tag.
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 """
 
-        expected_system_exit = """2020.02.01 has 4 packages with invalid maturity tag.
+        expected_system_exit = """2020.02.01-py38-rhel7.yml has 4 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag b packages: [('package_b1', 'v3.1.b1')]
 \tTag rc packages: [('package_rc1', 'v3.1.rc1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.a1 has 1 packages with invalid maturity tag.
+2020.02.a1-py38-rhel7.yml has 1 packages with invalid maturity tag.
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.b1 has 2 packages with invalid maturity tag.
+2020.02.b1-py38-rhel7.yml has 2 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
 
-2020.02.rc1 has 3 packages with invalid maturity tag.
+2020.02.rc1-py38-rhel7.yml has 3 packages with invalid maturity tag.
 \tTag a packages: [('package_a1', 'v3.1.a1')]
 \tTag b packages: [('package_b1', 'v3.1.b1')]
 \tTag invalid packages: [('package_iv1', '5.13.1-src')]
@@ -312,11 +312,11 @@ def test_get_files_to_lint(tmpdir):
         list_files_expected = _create_tmp_test_files(
             release_sample="pytest: 3.1.2",
             file_names_sample=[
-                "2020.02.01.yml",
-                "2020.02.a1.yml",
-                "2020.02.b1.yml",
-                "2020.02.rc1.yml",
-                "bleeding.yml",
+                "2020.02.01-py38-rhel7.yml",
+                "2020.02.a1-py38-rhel7.yml",
+                "2020.02.b1-py38-rhel7.yml",
+                "2020.02.rc1-py38-rhel7.yml",
+                "bleeding-py38-rhel7.yml",
             ],
         )
 
@@ -418,7 +418,7 @@ package_rc1: v3.1.rc1
 package_st1: v0.10.4
 package_iv1: 5.13.1-src
 package_ex2: testing/2020.3/rc1""",
-            file_names_sample=["2020.02.01.yml"],
+            file_names_sample=["2020.02.01-py38-rhel7.yml"],
         )
     monkeypatch.setattr(
         sys,
@@ -468,7 +468,7 @@ def test_argument_types(yaml_string: str, expectation, monkeypatch, tmpdir):
     with tmpdir.as_cwd():
         list_files_expected = _create_tmp_test_files(
             release_sample=yaml_string,
-            file_names_sample=["2020.02.01.yml"],
+            file_names_sample=["2020.02.01-py38-rhel7.yml"],
         )
     monkeypatch.setattr(sys, "argv", ["", "--release_file", list_files_expected[0]])
     with expectation:


### PR DESCRIPTION
Now that we again are aiming to build matrix builds (multiple rhel and python versions), then we need to lint on the "flat" transpiled release files and not the "raw" release files.