### PR TITLE
Handle non-sorted lists in dicts when comparing dicts

### DIFF
--- a/komodo/symlink/sanity_check.py
+++ b/komodo/symlink/sanity_check.py
@@ -91,10 +91,21 @@ def assert_root_nodes(link_dict):
         )
 
 
-def _compare_dicts(dict_1, dict_2):
+def _sort_lists_in_dicts(_dict: dict) -> dict:
+    result = {}
+    for key, value in _dict.items():
+        if isinstance(value, list):
+            result[key] = sorted(value)
+        else:
+            result[key] = value
+    return result
+
+
+def _compare_dicts(dict_1: dict, dict_2: dict) -> str:
     return "\n" + "\n".join(
         difflib.ndiff(
-            pprint.pformat(dict_1).splitlines(), pprint.pformat(dict_2).splitlines()
+            pprint.pformat(_sort_lists_in_dicts(dict_1)).splitlines(),
+            pprint.pformat(_sort_lists_in_dicts(dict_2)).splitlines(),
         ),
     )
 

--- a/tests/test_link_io_structure.py
+++ b/tests/test_link_io_structure.py
@@ -7,6 +7,8 @@ import pytest
 
 from komodo.symlink.create_links import create_symlinks, symlink_main
 from komodo.symlink.sanity_check import (
+    _compare_dicts,
+    _sort_lists_in_dicts,
     assert_root_nodes,
     equal_links,
     read_link_structure,
@@ -282,3 +284,11 @@ def test_executables(tmpdir):
             sanity_main()
     finally:
         sys.argv = old_argv
+
+
+def test_sort_lists_in_dicts():
+    assert _sort_lists_in_dicts({1: [2, 1]}) == {1: [1, 2]}
+
+
+def test_compare_dicts_handles_non_sorted_lists():
+    assert _compare_dicts({1: [2, 1]}, {1: [1, 2]}).strip() == "{1: [1, 2]}"


### PR DESCRIPTION
This makes the printed diff from the sanity checker make sense

Solves #481 