### PR TITLE
Allow CommentedMap when linting upgrade proposals

### DIFF
--- a/komodo/lint_upgrade_proposals.py
+++ b/komodo/lint_upgrade_proposals.py
@@ -17,20 +17,37 @@ def verify_package_versions_exist(
             upgrade_proposals_package,
             upgrade_proposals_package_version,
         ) in proposed_package_upgrades.items():
+
+            def extract_versions(nested_package_version) -> list:
+                package_versions = []
+                if isinstance(nested_package_version, dict):
+                    for nested_packages in nested_package_version.values():
+                        # pylint: disable=cell-var-from-loop
+                        package_versions.extend(extract_versions(nested_packages))
+                else:
+                    package_versions.append(nested_package_version)
+
+                return package_versions
+
+            upgrade_proposals_package_versions = extract_versions(
+                upgrade_proposals_package_version
+            )
+
             try:
-                repository.validate_package_entry(
-                    upgrade_proposals_package,
-                    upgrade_proposals_package_version,
-                )
-                print(
-                    f"Found package: '{upgrade_proposals_package}' with version"
-                    f" {upgrade_proposals_package_version} in repository",
-                )
+                for package_version in upgrade_proposals_package_versions:
+                    repository.validate_package_entry(
+                        upgrade_proposals_package,
+                        package_version,
+                    )
+                    print(
+                        f"Found package: '{upgrade_proposals_package}' with version"
+                        f" {package_version} in repository",
+                    )
             except KomodoException as komodo_exception:
                 errors.append("ERROR: " + komodo_exception.error)
         if errors:
             raise SystemExit("\n".join(errors))
-    if found_release_with_upgrades:
+    if not found_release_with_upgrades:
         print("No upgrades found")
     else:
         print("Found upgrades")

--- a/tests/test_lint_upgrade_proposals.py
+++ b/tests/test_lint_upgrade_proposals.py
@@ -112,6 +112,38 @@ VALID_UPGRADE_PROPOSALS_MULTIPLE_RELEASES = """
 1111-12:
   python: 3.8.6
 """
+
+VALID_UPGRADE_PROPOSALS_NESTED_ONE_LEVEL = """
+1111-12:
+  wheel:
+    py38: 0.40.0
+    py311: 0.40.0
+"""
+
+VALID_UPGRADE_PROPOSALS_NESTED_TWO_LEVEL = """
+1111-12:
+  wheel:
+    rhel7:
+      py38: 0.40.0
+    rhel8:
+      py38: 0.40.0
+      py311: 0.40.0
+"""
+
+VALID_UPGRADE_PROPOSALS_MULTI_NESTED = """
+1111-12:
+  python: 3.8.6
+  setuptools:
+    py38: 68.0.0
+    py311: 68.0.0
+  wheel:
+    rhel7:
+      py38: 0.40.0
+    rhel8:
+      py38: 0.40.0
+      py311: 0.40.0
+"""
+
 INVALID_UPGRADE_PROPOSALS_DUPLICATE_PACKAGES = """
 1111-11:
 1111-12:
@@ -216,6 +248,24 @@ yaml
                 match=r"Version '3.8.6' of package 'python' not found in repository",
             ),
             id="repository_file_missing_package_version",
+        ),
+        pytest.param(
+            VALID_UPGRADE_PROPOSALS_NESTED_ONE_LEVEL,
+            VALID_REPOSITORY,
+            does_not_raise(),
+            id="one_level_nested_package_versions_in_upgrade_proposals",
+        ),
+        pytest.param(
+            VALID_UPGRADE_PROPOSALS_NESTED_TWO_LEVEL,
+            VALID_REPOSITORY,
+            does_not_raise(),
+            id="two_level_nested_package_versions_in_upgrade_proposals",
+        ),
+        pytest.param(
+            VALID_UPGRADE_PROPOSALS_MULTI_NESTED,
+            VALID_REPOSITORY,
+            does_not_raise(),
+            id="combined_level_nested_package_versions_in_upgrade_proposals",
         ),
         pytest.param(
             INVALID_UPGRADE_PROPOSALS_DUPLICATE_PACKAGES,


### PR DESCRIPTION
```
2024-02:
2024-03:
2024-04:
  cwrap: 1.6.6
  everest: 0.33.4
  seba:
    py38: 7.5.0
    py311: 7.5.0
  dask:
    rhel7:
        py38: 2023.5.0
    rhel8:
        py38: 2023.5.0
        py311: 2024.4.0
    py38: 2024.4.0
```

Yields:

```
Found package: 'cwrap' with version 1.6.6 in repository
Found package: 'everest' with version 0.33.4 in repository
Found package: 'seba' with version 7.5.0 in repository
Found package: 'seba' with version 7.5.0 in repository
Found package: 'dask' with version 2023.5.0 in repository
Found package: 'dask' with version 2023.5.0 in repository
Found package: 'dask' with version 2024.4.0 in repository
Found package: 'dask' with version 2024.4.0 in repository
Found upgrades
Upgrade proposals file is valid!
```