### PR TITLE
Add package name to error messages

### DIFF
--- a/komodo/lint.py
+++ b/komodo/lint.py
@@ -22,7 +22,6 @@ Report = namedtuple(
     ["release_name", "maintainers", "dependencies", "versions"],
 )
 
-
 MISSING_PACKAGE = "missing package"
 MISSING_VERSION = "missing version"
 MISSING_DEPENDENCY = "missing dependency"
@@ -128,10 +127,12 @@ def lint(
 
         failed_requirements = dependencies.failed_requirements()
         if failed_requirements:
+            package_set = sorted(set(failed_requirements.values()))
             deps = [
                 _komodo_error(
-                    err="Failed requirements ",
+                    err="Failed requirements:",
                     depends=[str(r) for r in failed_requirements],
+                    package=", ".join(package_set),
                 )
             ]
         else:
@@ -200,6 +201,8 @@ def lint_main():
     for err in maintainers + deps + versions:
         if err.err:
             print(f"{err.err}")
+            if err.package:
+                print(f"{err.package}")
             if err.depends:
                 print("  " + "\n  ".join(err.depends))
 


### PR DESCRIPTION
Issue:
Only requirements are printed when komodo linting fails.
ref.
https://github.com/equinor/komodo-releases/actions/runs/10826893274/job/30038841723?pr=6267

Prints package name alongside requirements:
```
(rhel8-bleed-py38-env + bleeding-py38-rhel8) [andrli@st-lintgxt0002 komodo-releases]$ komodo-lint --check-pypi-dependencies releases/2024.10.b0-py38-rhel8.yml repository.yml
303 packages
Failed requirements
fmu-dataio
  pydantic<2.7.0,>=2.5.0
Error in komodo configuration.
```


Also, introducing an older version of `Semeio` cause this to happen;

```
(rhel8-env + 2024.09.02-py38-rhel8) [andrli@st-lintgx0138 komodo-releases]$ komodo-lint --check-pypi-dependencies releases/2024.10.b0-py38-rhel8.yml repository.yml
Not installed: ecl
Not installed: configsuite
Not installed: stea
303 packages
Failed requirements:
fmu-dataio, semeio
  pydantic<2.7.0,>=2.5.0
  ecl
  configsuite>=0.6
  stea
Error in komodo configuration.
```
