### PR TITLE
Avoid certain symlinks when checking for consistencies

### DIFF
--- a/komodo/symlink/sanity_check.py
+++ b/komodo/symlink/sanity_check.py
@@ -3,6 +3,7 @@ import difflib
 import json
 import os
 import pprint
+import re
 import sys
 
 
@@ -32,8 +33,16 @@ def read_link_structure(path):
     }
 
     list_of_files = [os.path.join(path, file_name) for file_name in os.listdir(path)]
+
+    bleeding_timestamp_pattern = r"bleeding-\d{8}-\d{4}-"
+    bleeding_deleteme_pattern = r"bleeding-.*\.deleteme"
+
     for file_path in list_of_files:
         file_name = os.path.basename(file_path)
+
+        if re.match(bleeding_timestamp_pattern, file_name) or re.match(bleeding_deleteme_pattern, file_name):
+            continue
+
         if os.path.islink(file_path):
             link_structure["links"][file_name] = os.path.basename(
                 os.readlink(file_path),

--- a/komodo/symlink/sanity_check.py
+++ b/komodo/symlink/sanity_check.py
@@ -36,14 +36,23 @@ def read_link_structure(path):
 
     bleeding_timestamp_pattern = r"bleeding-\d{8}-\d{4}-"
     bleeding_deleteme_pattern = r"bleeding-.*\.deleteme"
+    dangling_root_folders = [
+        "bleeding-py311-rhel8",
+        "bleeding-py38-rhel7",
+        "bleeding-py38-rhel8",
+    ]
 
     for file_path in list_of_files:
         file_name = os.path.basename(file_path)
 
-        if re.match(bleeding_timestamp_pattern, file_name) or re.match(bleeding_deleteme_pattern, file_name):
-            continue
-
-        if os.path.islink(file_path):
+        if not any(
+            [
+                re.match(bleeding_timestamp_pattern, file_name),
+                re.match(bleeding_deleteme_pattern, file_name),
+                file_name in dangling_root_folders,
+                not os.path.islink(file_path),
+            ]
+        ):
             link_structure["links"][file_name] = os.path.basename(
                 os.readlink(file_path),
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ disable = [
     "use-symbolic-message-instead",
     "useless-object-inheritance",
     "too-many-lines",
+    "too-many-positional-arguments",
 ]
 
 [tool.pylint.MASTER]

--- a/tests/test_link_io_structure.py
+++ b/tests/test_link_io_structure.py
@@ -24,10 +24,13 @@ def test_read_folder_structure(tmpdir):
         os.mkdir("2012.01.rc2")
         os.mkdir("bleeding")
         os.mkdir("2012.01.12")
+        os.mkdir("nowhere")
 
         os.symlink("2012.01.12", "2012.01")
         os.symlink("2012.01", "stable")
         os.symlink("2012.01.rc2", "testing")
+        os.symlink("nowhere", "bleeding-20242012-2313-py311")
+        os.symlink("nowhere", "bleeding-something.deleteme")
 
         expected_result = {
             "root_folder": tmpdir,

--- a/tests/test_link_io_structure.py
+++ b/tests/test_link_io_structure.py
@@ -30,7 +30,11 @@ def test_read_folder_structure(tmpdir):
         os.symlink("2012.01", "stable")
         os.symlink("2012.01.rc2", "testing")
         os.symlink("nowhere", "bleeding-20242012-2313-py311")
+        os.symlink("nowhere", "bleeding-20242012-2245-py38")
         os.symlink("nowhere", "bleeding-something.deleteme")
+        os.symlink("bleeding-20242012-2313-py38", "bleeding-py38-rhel7")
+        os.symlink("bleeding-20242012-2313-py38", "bleeding-py38-rhel8")
+        os.symlink("bleeding-20242012-2313-py311", "bleeding-py311-rhel8")
 
         expected_result = {
             "root_folder": tmpdir,


### PR DESCRIPTION
Resolves #512 

We have altered how symlinks are being interpreted when introducing multiple rhel-versions, and when introducing bleeding-timestamped builds.
The concept of root-link does not fully match here, where we source symlinks based on OS versions in enable scripts, and therefore have no clean linkage as we used to have.
