### PR TITLE
Remove non-functional last-install of komodo-shims

### DIFF
--- a/komodo/cli.py
+++ b/komodo/cli.py
@@ -292,11 +292,9 @@ def install_previously_downloaded_pip_packages(
             makeopts,
         ]
 
-    komodo_shims: Optional[Tuple[str, str]] = None
     for pkg, ver in release_file_content.items():
         if pkg == LAST_PIP_PACKAGE_TO_INSTALL:
             # This is a magic package name that will always be installed after all other pip packages if found.
-            komodo_shims = (pkg, ver)
             continue
         pkg_data = repository_file_content[pkg][ver]
         if pkg_data["make"] != "pip":
@@ -306,9 +304,6 @@ def install_previously_downloaded_pip_packages(
             pkg_data.get("pypi_package_name", pkg), ver, pkg_data.get("makeopts")
         )
         print(shell(shell_input))
-
-    if komodo_shims is not None:
-        print(shell(pip_shell_command(komodo_shims[0], komodo_shims[1], None)))
 
 
 def run_post_installation_scripts_if_set(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,12 +2,9 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import pytest
-import yaml
 
-from komodo import cli
 from komodo.cli import cli_main
 from tests import _get_test_root
 
@@ -237,54 +234,3 @@ def test_bleeding_builds_marked_for_deletion_are_removed(tmpdir):
     assert count_release_folders_to_be_deleted() == len(test_dirs)
     cli_main()
     assert count_release_folders_to_be_deleted() == 0
-
-
-def test_komodo_shims_is_installed_at_the_end(tmpdir):
-    (Path(tmpdir) / "release.yml").write_text(
-        "komodo-shims: 1.0.0\npython: 3-builtin\ntreelib: 1.7.0", encoding="utf-8"
-    )
-    repo = {
-        "python": {
-            "3-builtin": {
-                "make": "pip",  # because why not
-                "maintainer": "foo",
-            }
-        },
-        "treelib": {
-            "1.7.0": {
-                "source": "pypi",
-                "make": "pip",
-                "maintainer": "bar",
-                "depends": ["python"],
-            }
-        },
-        "komodo-shims": {
-            "1.0.0": {"source": "pypi", "make": "pip", "maintainer": "com"}
-        },
-    }
-    (Path(tmpdir) / "repository.yml").write_text(yaml.dump(repo), encoding="utf-8")
-    sys.argv = [
-        "kmd",
-        "--workspace",
-        str(tmpdir),
-        str(tmpdir / "release.yml"),
-        str(tmpdir / "repository.yml"),
-        "--release",
-        "a_komodo_release_with_shims",
-        "--prefix",
-        str(tmpdir),
-    ]
-
-    mocked_shell = Mock(return_value=b"")
-    mocked_fetch = Mock(return_value={})
-    with patch.object(cli, "shell", mocked_shell), patch.object(
-        cli, "fetch", mocked_fetch
-    ):
-        cli_main()
-    pip_install_calls = [
-        shell_call
-        for shell_call in mocked_shell.mock_calls
-        if "'pip', 'install " in str(shell_call.args[0])
-    ]
-    assert len(pip_install_calls) == 3
-    assert "komodo-shims" in str(pip_install_calls[-1])


### PR DESCRIPTION
This is a partial fix, as Komodo currently can't build if komodo-shims is included.

This is a backup PR if #554 cannot be merged right away.