### PR TITLE
Replace pylint usage with ruff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,12 +31,8 @@ jobs:
 
     - name: Lint with ruff
       run: |
-        ruff check komodo tests
+        ruff check .
     
-    - name: Format with ruff
+    - name: Verify formatting with ruff
       run: |
-        ruff format komodo tests --check
-
-    - name: pylint
-      run: |
-        pylint komodo tests
+        ruff format --diff .

--- a/komodo/build.py
+++ b/komodo/build.py
@@ -52,7 +52,7 @@ def cmake(
     Path(bdir).mkdir(parents=True, exist_ok=True)
     with pushd(bdir):
         os.environ["LD_LIBRARY_PATH"] = ld_lib_path
-        _pre_PATH = os.environ["PATH"]  # pylint: disable=invalid-name
+        _pre_PATH = os.environ["PATH"]
         os.environ["PATH"] = bin_path
 
         print(f"Installing {package_name} ({ver}) from source with cmake")
@@ -79,7 +79,7 @@ def sh(
     jobs=None,
     cmake=None,
     makeopts=None,
-):  # pylint: disable=invalid-name
+):
     makefile = data.get(makefile)
 
     with pushd(pkgpath):

--- a/komodo/lint.py
+++ b/komodo/lint.py
@@ -53,7 +53,7 @@ def lint_version_numbers(package, version, repo):
             parsed_version
         ):  # don't know if possible to check otherwise
             return KomodoError(package, version, maintainer)
-    except Exception as err:  # pylint: disable=broad-exception-caught
+    except Exception as err:
         # Log any exception:
         return KomodoError(package, version, maintainer, err=str(err))
     return None

--- a/komodo/lint_upgrade_proposals.py
+++ b/komodo/lint_upgrade_proposals.py
@@ -22,7 +22,6 @@ def verify_package_versions_exist(
                 package_versions = []
                 if isinstance(nested_package_version, dict):
                     for nested_packages in nested_package_version.values():
-                        # pylint: disable=cell-var-from-loop
                         package_versions.extend(extract_versions(nested_packages))
                 else:
                     package_versions.append(nested_package_version)

--- a/komodo/matrix.py
+++ b/komodo/matrix.py
@@ -23,7 +23,7 @@ def get_matrix(
     if custom_coordinate:
         if len(custom_coordinate) != 1:
             raise ValueError("custom_coordinate must contain exactly one item")
-        component_name, component_seq = next(iter(custom_coordinate.items()))  # pylint: disable=stop-iteration-return
+        component_name, component_seq = next(iter(custom_coordinate.items()))
 
     for product in itertools.product(rhel_versions, py_versions, component_seq):
         rh_ver, py_ver, other_ver = product

--- a/komodo/pypi_dependencies.py
+++ b/komodo/pypi_dependencies.py
@@ -52,7 +52,6 @@ def version_list_to_requirements(
     ]
 
 
-# pylint: disable=too-many-instance-attributes
 class PypiDependencies:
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,14 +118,14 @@ src = ["src"]
 line-length = 88
 [tool.ruff.lint]
 select = [
-  "W",   # pycodestyle
-  "I",   # isort
-  "B",   # flake-8-bugbear
-  "SIM", # flake-8-simplify
-  "F",   # pyflakes
-  "UP",  # pyupgrade
-  "PERF",  # perflint
-  "C4",  # flake8-comprehensions
+  "B",    # flake-8-bugbear
+  "C4",   # flake8-comprehensions
+  "F",    # pyflakes
+  "I",    # isort
+  "PERF", # perflint
+  "SIM",  # flake-8-simplify
+  "UP",   # pyupgrade
+  "W",    # pycodestyle
 ]
 
 ignore = ["PERF203"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
 dev = [
     "furo",
     "myst_parser",
-    "pylint",
     "pytest",
     "ruff",
     "sphinx",
@@ -74,45 +73,6 @@ komodo-suggest-symlinks = "komodo.symlink.suggester.cli:main"
 komodo-transpiler = "komodo.release_transpiler:main"
 komodo-check-unused = "komodo.check_unused_package:main"
 
-[tool.pylint.messages_control]
-disable = [
-    "bad-inline-option",
-    "consider-using-sys-exit",
-    "deprecated-pragma",
-    "duplicate-code",
-    "file-ignored",
-    "fixme",
-    "line-too-long",
-    "locally-disabled",
-    "logging-not-lazy",
-    "logging-fstring-interpolation", # Do not remove; it greatly decreases readability
-    "missing-class-docstring",
-    "missing-function-docstring",
-    "missing-module-docstring",
-    "no-else-return",
-    "protected-access",
-    "raise-missing-from",
-    "raw-checker-failed",
-    "redefined-outer-name",
-    "suppressed-message",
-    "too-few-public-methods",
-    "too-many-arguments",
-    "too-many-branches",
-    "too-many-locals",
-    "too-many-statements",
-    "use-a-generator",
-    "use-implicit-booleaness-not-comparison",
-    "use-symbolic-message-instead",
-    "useless-object-inheritance",
-    "too-many-lines",
-    "too-many-positional-arguments",
-]
-
-[tool.pylint.MASTER]
-ignore-paths = [
-    '^.*\\_version.py'
-]
-
 [tool.ruff]
 src = ["src"]
 line-length = 88
@@ -123,12 +83,26 @@ select = [
   "F",    # pyflakes
   "I",    # isort
   "PERF", # perflint
+  "PL",   # pylint
   "SIM",  # flake-8-simplify
   "UP",   # pyupgrade
   "W",    # pycodestyle
 ]
-
-ignore = ["PERF203"]
+ignore = [
+    "PERF203",  # try-except-in-loop
+    "PLR0912",  # Too many branches
+    "PLR0913",  # too-many-arguments
+    "PLR0915",  # Too many statements
+    "PLR1722",  # use sys.exit
+    "PLR2004",  # Magic value used in comparison
+    "PLR5501",  # use elif instead of else then if
+    "PLW2901",  # for loop variable overwritten
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["komodo"]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"docs/conf.py" = [
+    "PLR1711",  # useless return statement
+]

--- a/tests/test_up_to_date_pypi.py
+++ b/tests/test_up_to_date_pypi.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 import functools
 import os
 import pathlib


### PR DESCRIPTION
Not all exceptions that was needed for pylint is needed for ruff,
meaning they are not identical in their linting, but ruff is so much
faster we will let it decide.