### PR TITLE
Remove pointless overwriting of package_name

### DIFF
--- a/komodo/build.py
+++ b/komodo/build.py
@@ -248,8 +248,6 @@ def make(
             msg = "pypi_package_name is only valid when building with pip"
             raise ValueError(msg)
 
-        package_name = current.get("pypi_package_name", package_name)
-
         makeopts = current.get("makeopts", "")
         if extra_makeopts:
             makeopts = f"{makeopts} {extra_makeopts}"


### PR DESCRIPTION
The potentially aliased package name is only relevant for pip installs fetching from pypi, but this is no longer performed in this function, rendering the overwriting of the loop variable pointless.